### PR TITLE
iat 2313 - Set new isManagedByIat values on model data

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -267,11 +267,16 @@ migration:
 #        - migrationName: "migration2807"
 #          migrationDescription: "Migration2807: Validation: Duplicate attachment ID error on migrated braille files"
 #          migrateBranches: false
-    - migrationSetKey: "iat-31.31"
-      migrationDefinitions:
-        - migrationName: "migration2313"
-          migrationDescription: "Migration2313: Import rubric value, import qrx file and set interactive text to be non-editable until user discards imported values"
-          migrateBranches: true
+#    - migrationSetKey: "iat-31.31"
+#      migrationDefinitions:
+#        - migrationName: "migration2313Htqs"
+#          migrationDescription: "migration2313Htqs: Import rubric value, import qrx file and set interactive text to be non-editable until user discards imported values"
+#          migrateBranches: true
+#    - migrationSetKey: "iat-31.32"
+#      migrationDefinitions:
+#        - migrationName: "migration2313NonHtqs"
+#          migrationDescription: "Migration2313NonHtqs: Set Scoring.isManagedByIat and Scoring.machineScoringManagedByIat to true"
+#          migrateBranches: true
 
 
 ##########################################################################################################

--- a/application.yml
+++ b/application.yml
@@ -62,7 +62,7 @@ migration:
   publishReportEnabled: true
   syncFromGitlabEnabled: false
   includedItems:
-#  - 174654
+  - 47123
   data-store-migrations:
     enabled: true
     migrationSets:
@@ -267,7 +267,13 @@ migration:
 #        - migrationName: "migration2807"
 #          migrationDescription: "Migration2807: Validation: Duplicate attachment ID error on migrated braille files"
 #          migrateBranches: false
-#
+    - migrationSetKey: "iat-34.12"
+      migrationDefinitions:
+        - migrationName: "migration2313"
+          migrationDescription: "IAT-2313: Import rubric value, import qrx file and set interactive text to be non-editable until user discards imported values"
+          migrateBranches: true
+
+
 ##########################################################################################################
 #
 # Everything below is in preparation for the upcoming production release 3/9/2019.  Feel free to change

--- a/application.yml
+++ b/application.yml
@@ -62,7 +62,7 @@ migration:
   publishReportEnabled: true
   syncFromGitlabEnabled: false
   includedItems:
-  - 47123
+  - 42403
   data-store-migrations:
     enabled: true
     migrationSets:
@@ -267,10 +267,10 @@ migration:
 #        - migrationName: "migration2807"
 #          migrationDescription: "Migration2807: Validation: Duplicate attachment ID error on migrated braille files"
 #          migrateBranches: false
-    - migrationSetKey: "iat-34.12"
+    - migrationSetKey: "iat-31.31"
       migrationDefinitions:
         - migrationName: "migration2313"
-          migrationDescription: "IAT-2313: Import rubric value, import qrx file and set interactive text to be non-editable until user discards imported values"
+          migrationDescription: "Migration2313: Import rubric value, import qrx file and set interactive text to be non-editable until user discards imported values"
           migrateBranches: true
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ group=org.opentestsystem.ap
 
 version=0.1.79-SNAPSHOT
 
-commonVersion=0.4.118-SNAPSHOT
+commonVersion=0.4.118
 
 #leave blank, expected to be passed as property: "./gw -PnewCommonVersion=0.4.55 updateCommonVersion"
 newCommonVersion=

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ group=org.opentestsystem.ap
 
 version=0.1.79-SNAPSHOT
 
-commonVersion=0.4.116
+commonVersion=0.4.117-SNAPSHOT
 
 #leave blank, expected to be passed as property: "./gw -PnewCommonVersion=0.4.55 updateCommonVersion"
 newCommonVersion=

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ group=org.opentestsystem.ap
 
 version=0.1.79-SNAPSHOT
 
-commonVersion=0.4.117-SNAPSHOT
+commonVersion=0.4.118-SNAPSHOT
 
 #leave blank, expected to be passed as property: "./gw -PnewCommonVersion=0.4.55 updateCommonVersion"
 newCommonVersion=

--- a/src/main/java/org/opentestsystem/ap/migration/mapper/HtqsModelMapper.java
+++ b/src/main/java/org/opentestsystem/ap/migration/mapper/HtqsModelMapper.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.ap.migration.mapper;
 
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -12,7 +13,10 @@ import org.opentestsystem.ap.common.saaif.item.ItemRelease;
 import org.opentestsystem.ap.migration.model.ItemMappingProperties;
 import org.opentestsystem.ap.migration.model.ItemMappingResult;
 
+import javax.xml.bind.JAXBElement;
+import java.io.Serializable;
 import java.nio.file.Path;
+import java.util.Objects;
 
 @NoArgsConstructor
 public class HtqsModelMapper extends IatModelMapper {
@@ -35,8 +39,10 @@ public class HtqsModelMapper extends IatModelMapper {
                 mappingProperties = mapHtqsContent(content, mappingProperties);
 
                 htqsItem.getCore().getEn().setPrompt(mappingProperties.getContent());
+                htqsItem.getCore().getEn().getHtqSelectable().setManagedByIat(true);
                 htqsItem.getCore().getEn().getHtqSelectable()
                         .setInteractiveText(mappingProperties.getInteractiveText());
+                htqsItem.getCore().getScoring().setRubric(getRubricFromContent(content, mappingProperties));
 
                 this.setTextToSpeechFlags(htqsItem, mappingProperties);
             } else if (content.getLanguage().equals(ItemConstants.ItemLanguage.LANG_ESN)) {
@@ -44,6 +50,7 @@ public class HtqsModelMapper extends IatModelMapper {
                 htqsItem.getTranslations().getEsp().setIsRequired("true");
                 htqsItem.getTranslations().getEsp().setProvided(true);
                 htqsItem.getTranslations().getEsp().setPrompt(mappingProperties.getContent());
+                htqsItem.getTranslations().getEsp().getHtqSelectable().setManagedByIat(true);
                 htqsItem.getTranslations().getEsp().getHtqSelectable()
                         .setInteractiveText(mappingProperties.getInteractiveText());
             }
@@ -81,7 +88,7 @@ public class HtqsModelMapper extends IatModelMapper {
                     prompt.append(p.outerHtml());
                 } else {
                     interTextStarted = true;
-                    interText.append(convertInteractiveTagsToIat(p.outerHtml()));
+                    interText.append(p.outerHtml());
                 }
             }
         }
@@ -95,5 +102,32 @@ public class HtqsModelMapper extends IatModelMapper {
         mappingProperties.setInteractiveText(mappedInteractiveText);
 
         return mappingProperties;
+    }
+
+    private String getRubricFromContent(ItemRelease.Item.Content content, ItemMappingProperties mappingProperties) {
+        StringBuilder rubricContent = new StringBuilder();
+        if (!Objects.isNull(content.getRubriclist())) {
+            for (Serializable element : content.getRubriclist().getContent()) {
+                if (element instanceof JAXBElement) {
+                    JAXBElement jaxbElement = (JAXBElement) element;
+                    if (jaxbElement.getName().toString().equals("rubric")) {
+                        ItemRelease.Item.Content.Rubriclist.Rubric rubric =
+                                (ItemRelease.Item.Content.Rubriclist.Rubric) jaxbElement.getValue();
+                        String value = rubric.getVal();
+                        if (StringUtils.isNotBlank(value)) {
+                            rubricContent.append(mapRichTextContent(content.getLanguage(), removeHtmlEntities(value),
+                                    content.getApipAccessibility(), mappingProperties).getContent());
+                        }
+                    }
+                }
+            }
+        }
+        return rubricContent.toString();
+    }
+
+    private String removeHtmlEntities(String htmlContent) {
+        return htmlContent
+                .replace("&lt;", "")
+                .replace("&gt;", "");
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/mapper/HtqsModelMapper.java
+++ b/src/main/java/org/opentestsystem/ap/migration/mapper/HtqsModelMapper.java
@@ -39,18 +39,20 @@ public class HtqsModelMapper extends IatModelMapper {
                 mappingProperties = mapHtqsContent(content, mappingProperties);
 
                 htqsItem.getCore().getEn().setPrompt(mappingProperties.getContent());
-                htqsItem.getCore().getEn().getHtqSelectable().setManagedByIat(true);
+                htqsItem.getCore().getEn().getHtqSelectable().setManagedByIat(false);
                 htqsItem.getCore().getEn().getHtqSelectable()
                         .setInteractiveText(mappingProperties.getInteractiveText());
                 htqsItem.getCore().getScoring().setRubric(getRubricFromContent(content, mappingProperties));
+                htqsItem.getCore().getScoring().setManagedByIat(false);
 
                 this.setTextToSpeechFlags(htqsItem, mappingProperties);
             } else if (content.getLanguage().equals(ItemConstants.ItemLanguage.LANG_ESN)) {
                 mappingProperties = mapHtqsContent(content, mappingProperties);
                 htqsItem.getTranslations().getEsp().setIsRequired("true");
                 htqsItem.getTranslations().getEsp().setProvided(true);
+
                 htqsItem.getTranslations().getEsp().setPrompt(mappingProperties.getContent());
-                htqsItem.getTranslations().getEsp().getHtqSelectable().setManagedByIat(true);
+                htqsItem.getTranslations().getEsp().getHtqSelectable().setManagedByIat(false);
                 htqsItem.getTranslations().getEsp().getHtqSelectable()
                         .setInteractiveText(mappingProperties.getInteractiveText());
             }

--- a/src/main/java/org/opentestsystem/ap/migration/mapper/HtqsModelMapper.java
+++ b/src/main/java/org/opentestsystem/ap/migration/mapper/HtqsModelMapper.java
@@ -43,7 +43,6 @@ public class HtqsModelMapper extends IatModelMapper {
                 htqsItem.getCore().getEn().getHtqSelectable()
                         .setInteractiveText(mappingProperties.getInteractiveText());
                 htqsItem.getCore().getScoring().setRubric(getRubricFromContent(content, mappingProperties));
-                htqsItem.getCore().getScoring().setManagedByIat(false);
 
                 this.setTextToSpeechFlags(htqsItem, mappingProperties);
             } else if (content.getLanguage().equals(ItemConstants.ItemLanguage.LANG_ESN)) {
@@ -66,6 +65,9 @@ public class HtqsModelMapper extends IatModelMapper {
 
         // Import Qrx file
         processMachineRubric(htqsItem, release.getItem(), itemSourceFullPath, itemDestinationFullPath, mappingResult);
+
+        htqsItem.getCore().getScoring().setManagedByIat(true);
+        htqsItem.getCore().getScoring().setMachineScoringManagedByIat(false);
 
         return htqsItem;
     }

--- a/src/main/java/org/opentestsystem/ap/migration/mapper/IatModelMapper.java
+++ b/src/main/java/org/opentestsystem/ap/migration/mapper/IatModelMapper.java
@@ -395,8 +395,8 @@ public abstract class IatModelMapper {
         } else {
             iatVersion = "0.0";
         }
-
         itemMetadata.setVersion(iatVersion);
+
         itemMetadata.setWordCount(defaultString(smarterAppMetadata.getWordCount()));
 
         itemMetadata.setWritingPurpose(

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313.java
@@ -48,8 +48,7 @@ public class Migration2313 extends AbstractImportMigration {
         HtqsItem mappedHtqsItem = (HtqsItem) mappedItem;
 
         entityHtqsItem.setCore(mappedHtqsItem.getCore());
-        entityHtqsItem.getCore().getEn().setManagedByIat(true);
-        entityHtqsItem.getCore().getScoring().setRubric(mappedHtqsItem.getCore().getScoring().getRubric());
+        entityHtqsItem.setTranslations(mappedHtqsItem.getTranslations());
 
         migrateImportQrxFile(itemSyncDir, dataStoreItem);
 

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313.java
@@ -1,0 +1,90 @@
+package org.opentestsystem.ap.migration.migration;
+
+import com.google.common.collect.Sets;
+import com.google.common.io.Files;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.eclipse.jgit.util.StringUtils;
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
+import org.opentestsystem.ap.common.model.HtqsItem;
+import org.opentestsystem.ap.common.model.Item;
+import org.opentestsystem.ap.common.model.ItemConstants;
+import org.opentestsystem.ap.migration.ApplicationDependencyProvider;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.datastore.DataStoreItemResult;
+import org.opentestsystem.ap.migration.model.ItemMerge;
+import org.opentestsystem.ap.migration.model.SkipMigration;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class Migration2313 extends AbstractImportMigration {
+
+    public Migration2313(ApplicationProperties applicationProperties,
+                         DataStoreDataManager dataManager,
+                         ItemManagerEventProducer eventProducer,
+                         DataStoreUtility dataStoreUtility,
+                         DataStoreAttachmentManager dataStoreAttachmentManager,
+                         ApplicationDependencyProvider applicationDependencyProvider) {
+        super(applicationProperties, dataManager, eventProducer, dataStoreUtility,
+                dataStoreAttachmentManager, applicationDependencyProvider, ItemConstants.ItemType.TYPE_HTQS);
+    }
+
+    @Override
+    ItemMerge mergeItem(Item dataStoreItem, Item mappedItem, Path itemSyncDir) {
+        HtqsItem entityHtqsItem = (HtqsItem) dataStoreItem;
+        HtqsItem mappedHtqsItem = (HtqsItem) mappedItem;
+
+        entityHtqsItem.setCore(mappedHtqsItem.getCore());
+        entityHtqsItem.getCore().getEn().setManagedByIat(true);
+        entityHtqsItem.getCore().getScoring().setRubric(mappedHtqsItem.getCore().getScoring().getRubric());
+
+        migrateImportQrxFile(itemSyncDir, dataStoreItem);
+
+        return new ItemMerge(entityHtqsItem, itemSyncDir, true);
+    }
+
+    @Override
+    Collection<String> getEditedSectionsBlockingMigration() {
+        return Sets.newHashSet(ItemConstants.Section.SECTION_CORE,
+                ItemConstants.Section.SECTION_GLOSSARY,
+                ItemConstants.Section.SECTION_IMAGES,
+                ItemConstants.Section.SECTION_TRANSLATIONS);
+    }
+
+    private void migrateImportQrxFile(Path itemSyncDir, Item dataStoreItem) {
+        Path path = Files.createTempDir().toPath();
+
+        File[] itemSyncDirFiles = itemSyncDir.toFile().listFiles();
+        if (itemSyncDirFiles == null) {
+            throw new SkipMigration("Migration2313: No QRX file to migrate for item " + dataStoreItem.getId());
+        }
+
+        Optional<File> maybeQrxFile = Arrays.stream(itemSyncDirFiles)
+                .filter(file -> StringUtils.equalsIgnoreCase("qrx", FilenameUtils.getExtension(file.getName())))
+                .findFirst();
+
+        if (!maybeQrxFile.isPresent()) {
+            throw new SkipMigration("Migration2313: No QRX file to migrate for item " + dataStoreItem.getId());
+        }
+
+        File targetFile = new File(path.toFile(), maybeQrxFile.get().getName());
+        try {
+            FileUtils.copyFile(maybeQrxFile.get(), targetFile);
+        } catch (IOException e) {
+            throw new RuntimeException("Migration2313: could not copy qrx file " + maybeQrxFile.get().getName());
+        }
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313Htqs.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313Htqs.java
@@ -46,14 +46,13 @@ public class Migration2313Htqs extends AbstractImportMigration {
         HtqsItem entityHtqsItem = (HtqsItem) dataStoreItem;
         HtqsItem mappedHtqsItem = (HtqsItem) mappedItem;
 
-        entityHtqsItem.setCore(mappedHtqsItem.getCore());
-        entityHtqsItem.setTranslations(mappedHtqsItem.getTranslations());
-        entityHtqsItem.getCore().getScoring().setManagedByIat(true);
-        entityHtqsItem.getCore().getScoring().setMachineScoringManagedByIat(false);
+        entityHtqsItem.getCore().setEn(mappedHtqsItem.getCore().getEn());
+        entityHtqsItem.getTranslations().setEsp(mappedHtqsItem.getTranslations().getEsp());
+        entityHtqsItem.getCore().setScoring(mappedHtqsItem.getCore().getScoring());
 
-        migrateImportQrxFile(itemSyncDir, dataStoreItem);
+        Path migratedQrx = migrateImportQrxFile(itemSyncDir, dataStoreItem);
 
-        return new ItemMerge(entityHtqsItem, itemSyncDir, true);
+        return new ItemMerge(entityHtqsItem, migratedQrx, true);
     }
 
     @Override
@@ -63,7 +62,7 @@ public class Migration2313Htqs extends AbstractImportMigration {
                 ItemConstants.Section.SECTION_IMAGES);
     }
 
-    private void migrateImportQrxFile(Path itemSyncDir, Item dataStoreItem) {
+    private Path migrateImportQrxFile(Path itemSyncDir, Item dataStoreItem) {
         Path path = Files.createTempDir().toPath();
 
         File[] itemSyncDirFiles = itemSyncDir.toFile().listFiles();
@@ -85,5 +84,7 @@ public class Migration2313Htqs extends AbstractImportMigration {
         } catch (IOException e) {
             throw new RuntimeException("Migration2313: could not copy qrx file " + maybeQrxFile.get().getName());
         }
+
+        return path;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313Htqs.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313Htqs.java
@@ -9,14 +9,12 @@ import org.eclipse.jgit.util.StringUtils;
 import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
 import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
 import org.opentestsystem.ap.common.datastore.DataStoreUtility;
-import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
 import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
 import org.opentestsystem.ap.common.model.HtqsItem;
 import org.opentestsystem.ap.common.model.Item;
 import org.opentestsystem.ap.common.model.ItemConstants;
 import org.opentestsystem.ap.migration.ApplicationDependencyProvider;
 import org.opentestsystem.ap.migration.ApplicationProperties;
-import org.opentestsystem.ap.migration.datastore.DataStoreItemResult;
 import org.opentestsystem.ap.migration.model.ItemMerge;
 import org.opentestsystem.ap.migration.model.SkipMigration;
 import org.springframework.stereotype.Component;
@@ -30,25 +28,28 @@ import java.util.Optional;
 
 @Slf4j
 @Component
-public class Migration2313 extends AbstractImportMigration {
+public class Migration2313Htqs extends AbstractImportMigration {
 
-    public Migration2313(ApplicationProperties applicationProperties,
-                         DataStoreDataManager dataManager,
-                         ItemManagerEventProducer eventProducer,
-                         DataStoreUtility dataStoreUtility,
-                         DataStoreAttachmentManager dataStoreAttachmentManager,
-                         ApplicationDependencyProvider applicationDependencyProvider) {
+    public Migration2313Htqs(ApplicationProperties applicationProperties,
+                             DataStoreDataManager dataManager,
+                             ItemManagerEventProducer eventProducer,
+                             DataStoreUtility dataStoreUtility,
+                             DataStoreAttachmentManager dataStoreAttachmentManager,
+                             ApplicationDependencyProvider applicationDependencyProvider) {
         super(applicationProperties, dataManager, eventProducer, dataStoreUtility,
                 dataStoreAttachmentManager, applicationDependencyProvider, ItemConstants.ItemType.TYPE_HTQS);
     }
 
     @Override
     ItemMerge mergeItem(Item dataStoreItem, Item mappedItem, Path itemSyncDir) {
+        // This should only happen for ItemType.TYPE_HTQS
         HtqsItem entityHtqsItem = (HtqsItem) dataStoreItem;
         HtqsItem mappedHtqsItem = (HtqsItem) mappedItem;
 
         entityHtqsItem.setCore(mappedHtqsItem.getCore());
         entityHtqsItem.setTranslations(mappedHtqsItem.getTranslations());
+        entityHtqsItem.getCore().getScoring().setManagedByIat(true);
+        entityHtqsItem.getCore().getScoring().setMachineScoringManagedByIat(false);
 
         migrateImportQrxFile(itemSyncDir, dataStoreItem);
 
@@ -59,8 +60,7 @@ public class Migration2313 extends AbstractImportMigration {
     Collection<String> getEditedSectionsBlockingMigration() {
         return Sets.newHashSet(ItemConstants.Section.SECTION_CORE,
                 ItemConstants.Section.SECTION_GLOSSARY,
-                ItemConstants.Section.SECTION_IMAGES,
-                ItemConstants.Section.SECTION_TRANSLATIONS);
+                ItemConstants.Section.SECTION_IMAGES);
     }
 
     private void migrateImportQrxFile(Path itemSyncDir, Item dataStoreItem) {

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313NonHtqs.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313NonHtqs.java
@@ -10,6 +10,7 @@ import org.opentestsystem.ap.common.model.ItemConstants;
 import org.opentestsystem.ap.migration.ApplicationDependencyProvider;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.datastore.AbstractDataStoreMigration;
+import org.opentestsystem.ap.migration.util.ImportFileUtil;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,11 +22,7 @@ public class Migration2313NonHtqs extends AbstractDataStoreMigration {
 
     @Override
     protected ItemEntity migrateEntity(ItemEntity itemEntity) {
-        String entityType = itemEntity.getItemJson().getType();
-        if (!ItemConstants.ItemType.TYPE_HTQS.equalsIgnoreCase(entityType) &&
-                !ItemConstants.ItemType.TYPE_STIM.equalsIgnoreCase(entityType) &&
-                !ItemConstants.ItemType.TYPE_TUT.equalsIgnoreCase(entityType)) {
-
+        if (shouldMigrateItem(itemEntity)) {
             AssessmentItem item = (AssessmentItem) itemEntity.getItemJson();
             item.getCore().getScoring().setManagedByIat(true);
             item.getCore().getScoring().setMachineScoringManagedByIat(true);
@@ -33,5 +30,17 @@ public class Migration2313NonHtqs extends AbstractDataStoreMigration {
             itemEntity.setItemJson(item);
         }
         return itemEntity;
+    }
+
+    /**
+     * Apply migration to all items except TUT and non-imported HTQS
+     * @param itemEntity
+     * @return
+     */
+    private boolean shouldMigrateItem(ItemEntity itemEntity) {
+        String entityType = itemEntity.getItemJson().getType();
+        return !ItemConstants.ItemType.TYPE_TUT.equalsIgnoreCase(entityType) &&
+               (ItemConstants.ItemType.TYPE_HTQS.equalsIgnoreCase(entityType)
+                       && !ImportFileUtil.isImported(itemEntity.getItemJson()));
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313NonHtqs.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2313NonHtqs.java
@@ -1,0 +1,37 @@
+package org.opentestsystem.ap.migration.migration;
+
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
+import org.opentestsystem.ap.common.model.AssessmentItem;
+import org.opentestsystem.ap.common.model.ItemConstants;
+import org.opentestsystem.ap.migration.ApplicationDependencyProvider;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.datastore.AbstractDataStoreMigration;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Migration2313NonHtqs extends AbstractDataStoreMigration {
+
+    public Migration2313NonHtqs(ApplicationDependencyProvider applicationDependencyProvider, ApplicationProperties applicationProperties, DataStoreDataManager dataManager, ItemManagerEventProducer eventProducer, DataStoreUtility dataStoreUtility, DataStoreAttachmentManager dataStoreAttachmentManager) {
+        super(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager);
+    }
+
+    @Override
+    protected ItemEntity migrateEntity(ItemEntity itemEntity) {
+        String entityType = itemEntity.getItemJson().getType();
+        if (!ItemConstants.ItemType.TYPE_HTQS.equalsIgnoreCase(entityType) &&
+                !ItemConstants.ItemType.TYPE_STIM.equalsIgnoreCase(entityType) &&
+                !ItemConstants.ItemType.TYPE_TUT.equalsIgnoreCase(entityType)) {
+
+            AssessmentItem item = (AssessmentItem) itemEntity.getItemJson();
+            item.getCore().getScoring().setManagedByIat(true);
+            item.getCore().getScoring().setMachineScoringManagedByIat(true);
+
+            itemEntity.setItemJson(item);
+        }
+        return itemEntity;
+    }
+}


### PR DESCRIPTION
Two new model properties have been added:
`HtqSelectable.isManagedByIat` and `Scoring.machineScoringManagedByIat`

**Migration2313Htqs.java**
On Htqs items:
* Sets`HtqSelectable.isManagedByIat = false` (via `HtqsModelMapper.java`)
* Sets `Scoring.isManagedByIat = true` (existing field)
* Sets `Scoring.machineScoringManagedByIat = false`
* Restores the initial qrx file from import.zip

 **Migration2313NonHtqs.java**
On Non-Htqs, Stim and Tutorial items:
* Sets `Scoring.isManagedByIat = true` 
* Sets `Scoring.machineScoringManagedByIat = true`
These are the default values a new item will receive
