### PR TITLE
Added configuration for IAT-2366

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -248,6 +248,9 @@ migration:
           - migrationName: "migrationGenerateSaaif"
             migrationDescription: "IAT-2876: Status element missing in metadata.xml"
             onlySyncToGitlab: true
+          - migrationName: "migrationGenerateSaaif"
+            migrationDescription: "IAT-2366: Image alt text error is generated against embedded MathML"
+            onlySyncToGitlab: true
 ---
 spring:
   profiles: dev

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ group=org.opentestsystem.ap
 
 version=0.1.85-SNAPSHOT
 
-commonVersion=0.4.123
+commonVersion=0.4.124
 
 #leave blank, expected to be passed as property: "./gw -PnewCommonVersion=0.4.55 updateCommonVersion"
 newCommonVersion=


### PR DESCRIPTION
Added configuration for IAT-2366: Image alt text error is generated against embedded MathML