### PR TITLE
iat 2921 - Rich text (Bolding) formatting was lost during recent migrations

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -330,7 +330,9 @@ migration:
           - migrationName: "migration2854Import"
             migrationDescription: "IAT-2854: Imported items: Import Cleanup: EnemyItem value is was not imported"
             requiresImportFiles: true
-
+          - migrationName: "migration2921"
+            migrationDescription: "IAT-2921: Rich text (Bolding) formatting was lost during recent migrations"
+            requiresImportFiles: true
 ---
 spring:
   profiles: dev

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2776.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2776.java
@@ -37,7 +37,7 @@ public class Migration2776 extends AbstractDataStoreMigration {
 
         styleBlackList.add("line-height:0.2402in;");
         styleBlackList.add("color:#000000;");
-        styleBlackList.add("font-weight:bold;");
+//        styleBlackList.add("font-weight:bold;");
         styleBlackList.add("font-style:normal;");
         styleBlackList.add("font-weight:normal;");
         styleBlackList.add("font-variant:normal;");

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2921.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2921.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 @Component
 public class Migration2921 extends AbstractImportMigration {
-    private static final String BOLD_STYLE = "<span style=\"font-weight:bold;";
+    private static final String BOLD_STYLE = "font-weight:bold;";
 
     public Migration2921(ApplicationProperties applicationProperties, DataStoreDataManager dataManager, ItemManagerEventProducer eventProducer, DataStoreUtility dataStoreUtility, DataStoreAttachmentManager dataStoreAttachmentManager, ApplicationDependencyProvider applicationDependencyProvider) {
         super(applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager, applicationDependencyProvider);

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2921.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2921.java
@@ -1,0 +1,47 @@
+package org.opentestsystem.ap.migration.migration;
+
+import com.google.common.collect.Sets;
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
+import org.opentestsystem.ap.common.model.Item;
+import org.opentestsystem.ap.common.model.ItemConstants;
+import org.opentestsystem.ap.common.saaif.model.ImportItem;
+import org.opentestsystem.ap.common.saaif.model.SkipMigration;
+import org.opentestsystem.ap.migration.ApplicationDependencyProvider;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.model.ItemMerge;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.Collection;
+
+@Component
+public class Migration2921 extends AbstractImportMigration {
+    private static final String BOLD_STYLE = "<span style=\"font-weight:bold;";
+
+    public Migration2921(ApplicationProperties applicationProperties, DataStoreDataManager dataManager, ItemManagerEventProducer eventProducer, DataStoreUtility dataStoreUtility, DataStoreAttachmentManager dataStoreAttachmentManager, ApplicationDependencyProvider applicationDependencyProvider) {
+        super(applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager, applicationDependencyProvider);
+    }
+
+    @Override
+    protected ItemMerge mergeItem(Item dataStoreItem, Item mappedItem, Path itemSyncDir) {
+        dataStoreItem.getCore().setEn(mappedItem.getCore().getEn());
+        dataStoreItem.getTranslations().setEsp(mappedItem.getTranslations().getEsp());
+        return new ItemMerge(dataStoreItem, itemSyncDir, false);
+    }
+
+    @Override
+    protected Collection<String> getEditedSectionsBlockingMigration() {
+        return Sets.newHashSet(ItemConstants.Section.SECTION_CORE,
+                ItemConstants.Section.SECTION_TRANSLATIONS);
+    }
+
+    @Override
+    protected void checkSkipMigration(ImportItem importItem) {
+        if (!findTextInItemFile(importItem, BOLD_STYLE)) {
+            throw new SkipMigration(String.format("the saaif content does not contain %s", BOLD_STYLE));
+        }
+    }
+}


### PR DESCRIPTION
Restore "bold" formatting to unedited imported items