### PR TITLE
IAT-3177 - Certain TTS tags were written incorrectly during a recent migration

### DIFF
--- a/application-items.yml
+++ b/application-items.yml
@@ -2,10 +2,4 @@ migration:
   # Item ids that need to be copied here.  It should be the id only (not item-200-).  Associated files like
   # stim and tutorials are not included.
   includedItems:
-    - 183302
-    - 193770
-    - 193804
-    - 34357
-    - 45751
-    - 89554
-    - 79931
+    - 72860

--- a/application-items.yml
+++ b/application-items.yml
@@ -2,6 +2,10 @@ migration:
   # Item ids that need to be copied here.  It should be the id only (not item-200-).  Associated files like
   # stim and tutorials are not included.
   includedItems:
-    - 180667
-    - 181075
-    - 201510
+    - 183302
+    - 193770
+    - 193804
+    - 34357
+    - 45751
+    - 89554
+    - 79931

--- a/application-items.yml
+++ b/application-items.yml
@@ -2,4 +2,6 @@ migration:
   # Item ids that need to be copied here.  It should be the id only (not item-200-).  Associated files like
   # stim and tutorials are not included.
   includedItems:
-    - 72860
+    - 180667
+    - 181075
+    - 201510

--- a/application.yml
+++ b/application.yml
@@ -74,7 +74,7 @@ migration:
   imrt:
     syncUrlPattern: "http://localhost:9081/sync/%s"
   includedItems:
-    - 4340
+#    - 33413
   data-store-migrations:
     enabled: true
     migrationSets:
@@ -502,6 +502,11 @@ migration:
             migrationDescription: "IAT-3230: TI does not save the rubric value within the saaif rubric field"
             requiresImportFiles: false
             onlySyncToGitlab: true
+      - migrationSetKey: "iat-42.1"
+        migrationDefinitions:
+          - migrationName: "migration3177"
+            migrationDescription: "IAT-3177: Certain TTS tags were written incorrectly during a recent migration"
+            requiresImportFiles: true
 
 ---
 spring:

--- a/application.yml
+++ b/application.yml
@@ -63,7 +63,7 @@ migration:
   syncFromGitlabEnabled: false
   copySourceToTargetEnabled: false
   deleteItemsEnabled: false
-  validateMigrationSets: true
+  validateMigrationSets: false
   itemFileLocation: ${tims.copy.item.file.location}
   syncWithImrt: false
   sourceBank:
@@ -74,7 +74,7 @@ migration:
   imrt:
     syncUrlPattern: "http://localhost:9081/sync/%s"
   includedItems:
-    - 4340
+    - 33413
   data-store-migrations:
     enabled: true
     migrationSets:
@@ -498,6 +498,9 @@ migration:
             migrationDescription: "IAT-3246: Imported styling remains on some items and does not render in preview"
             requiresImportFiles: false
             migrateBranches: true
+          - migrationName: "migrationGenerateSaaif"
+            migrationDescription: "IAT-3177: Certain TTS tags were written incorrectly during a recent migration"
+            onlySyncToGitlab: true
 
 ---
 spring:

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ group=org.opentestsystem.ap
 
 version=0.5.22-SNAPSHOT
 
-commonVersion=0.5.20
+commonVersion=0.5.23
 
 configServerVersion=3.1.0.RELEASE
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ group=org.opentestsystem.ap
 
 version=0.5.24-SNAPSHOT
 
-commonVersion=0.5.23
+commonVersion=0.5.25
 
 configServerVersion=3.1.0.RELEASE
 

--- a/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/Migration3177.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/Migration3177.java
@@ -1,0 +1,106 @@
+package org.opentestsystem.ap.migration.migration.migration3177;
+
+import lombok.extern.slf4j.Slf4j;
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
+import org.opentestsystem.ap.common.model.Item;
+import org.opentestsystem.ap.common.model.ModelConstants;
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.common.saaif.mapper.model.ImportItem;
+import org.opentestsystem.ap.common.saaif.mapper.model.SkipMigration;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdater;
+import org.opentestsystem.ap.migration.migration.AbstractImportMigration;
+import org.opentestsystem.ap.migration.model.ItemMerge;
+import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.opentestsystem.ap.common.model.ModelConstants.ItemType.TYPE_STIM;
+import static org.opentestsystem.ap.common.model.ModelConstants.ItemType.TYPE_TUT;
+
+@Slf4j
+@Component
+public class Migration3177 extends AbstractImportMigration {
+
+    public Migration3177(ApplicationProperties applicationProperties,
+                         DataStoreDataManager dataManager,
+                         ItemManagerEventProducer eventProducer,
+                         DataStoreUtility dataStoreUtility,
+                         DataStoreAttachmentManager dataStoreAttachmentManager,
+                         ApplicationDependencyProvider applicationDependencyProvider) {
+        super(applicationProperties, dataManager, eventProducer, dataStoreUtility,
+                dataStoreAttachmentManager, applicationDependencyProvider);
+    }
+
+    @Override
+    protected ItemMerge mergeItem(Item dataStoreItem, Item mappedItem, Path itemSyncDir) {
+        // Do nothing with the dataStoreItem. Merge work occurs in mergeItemFromImportData
+        return new ItemMerge(dataStoreItem, itemSyncDir, DO_NOT_SYNC_ATTACHMENTS);
+    }
+
+    @Override
+    protected ItemMerge mergeItemFromImportData(ItemMerge itemMerge, ImportItem importItem, Path itemSyncDir) {
+        TtsContentUpdateCommand updateCommand = new TtsContentUpdateCommand(importItem.getItemRelease());
+        ContentUpdater contentUpdater = this.contentUpdaterFactory.getContentUpdaterForType(itemMerge.getMergedItem().getType());
+        contentUpdater.updateContent(itemMerge.getMergedItem(), updateCommand);
+        return new ItemMerge(itemMerge.getMergedItem(), itemSyncDir, false);
+    }
+
+    @Override
+    protected void checkSkipMigration(ItemEntity itemEntity) {
+        if (TYPE_TUT.equals(
+                itemEntity.getItemJson().getType())) {
+            throw new SkipMigration(String.format("Item %s is a Tutorial. No updates necessary", itemEntity.getItemId()));
+        }
+    }
+
+    @Override
+    protected void checkSkipMigration(ImportItem importItem) {
+        boolean ttsExists;
+        if (TYPE_STIM.equals(importItem.getItemProps().getItemType())) {
+            ttsExists = doPassageTTSElementsExist(importItem.getItemRelease().getPassage().getContent());
+        } else {
+            ttsExists = doItemTTSElementsExist(importItem.getItemRelease().getItem().getContent());
+        }
+        if (!ttsExists) {
+            throw new SkipMigration(
+                    String.format("Item %s has no TTS <accessElement> . No updates necessary", importItem.getItemProps().getItemId()));
+        }
+    }
+
+    @Override
+    protected Collection<String> getEditedSectionsBlockingMigration() {
+        return Collections.emptyList();
+    }
+
+    private boolean doPassageTTSElementsExist(List<ItemRelease.Passage.Content> contentList) {
+        Optional<ItemRelease.Passage.Content> englishContent =
+                contentList
+                        .stream()
+                        .filter(content -> content.getLanguage().equals(ModelConstants.ItemLanguage.LANG_ENU))
+                        .findFirst();
+        return englishContent.filter(saaifContent -> Objects.nonNull(saaifContent.getApipAccessibility()
+                .getAccessibilityInfo().getAccessElement())).isPresent();
+    }
+
+    private boolean doItemTTSElementsExist(List<ItemRelease.Item.Content> contentList) {
+        Optional<ItemRelease.Item.Content> englishContent =
+                contentList
+                        .stream()
+                        .filter(content -> content.getLanguage().equals(ModelConstants.ItemLanguage.LANG_ENU))
+                        .findFirst();
+        return englishContent.filter(saaifContent -> Objects.nonNull(saaifContent.getApipAccessibility()
+                .getAccessibilityInfo().getAccessElement())).isPresent();
+    }
+
+}

--- a/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/Migration3177.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/Migration3177.java
@@ -66,10 +66,10 @@ public class Migration3177 extends AbstractImportMigration {
 
     @Override
     protected void checkSkipMigration(ImportItem importItem) {
-        boolean ttsExists;
-        if (TYPE_STIM.equals(importItem.getItemProps().getItemType())) {
+        boolean ttsExists = false;
+        if (isStim(importItem.getItemRelease())) {
             ttsExists = doPassageTTSElementsExist(importItem.getItemRelease().getPassage().getContent());
-        } else {
+        } else if (isItem(importItem.getItemRelease())) {
             ttsExists = doItemTTSElementsExist(importItem.getItemRelease().getItem().getContent());
         }
         if (!ttsExists) {
@@ -83,6 +83,12 @@ public class Migration3177 extends AbstractImportMigration {
         return Collections.emptyList();
     }
 
+    /**
+     * Checks if the import ItemRelease.Passage contains <accessElement></accessElement> elements
+     *
+     * @param contentList    List of ItemRelease.Passage.Content
+     * @return               when true, the ItemRelease.Passage.Content contains <accessElement></accessElement>
+     */
     private boolean doPassageTTSElementsExist(List<ItemRelease.Passage.Content> contentList) {
         Optional<ItemRelease.Passage.Content> englishContent =
                 contentList
@@ -93,6 +99,12 @@ public class Migration3177 extends AbstractImportMigration {
                 .getAccessibilityInfo().getAccessElement())).isPresent();
     }
 
+    /**
+     * Checks if the import ItemRelease.Item contains <accessElement></accessElement> elements
+     *
+     * @param contentList    List of ItemRelease.Item.Content
+     * @return               when true, the ItemRelease.Item.Content contains <accessElement></accessElement>
+     */
     private boolean doItemTTSElementsExist(List<ItemRelease.Item.Content> contentList) {
         Optional<ItemRelease.Item.Content> englishContent =
                 contentList
@@ -101,6 +113,14 @@ public class Migration3177 extends AbstractImportMigration {
                         .findFirst();
         return englishContent.filter(saaifContent -> Objects.nonNull(saaifContent.getApipAccessibility()
                 .getAccessibilityInfo().getAccessElement())).isPresent();
+    }
+
+    private boolean isStim(ItemRelease release) {
+        return Objects.nonNull(release.getPassage());
+    }
+
+    private boolean isItem(ItemRelease release) {
+        return Objects.nonNull(release.getItem());
     }
 
 }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/TtsContentUpdateCommand.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/TtsContentUpdateCommand.java
@@ -1,0 +1,28 @@
+package org.opentestsystem.ap.migration.migration.migration3177;
+
+import org.jsoup.nodes.Document;
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+
+public class TtsContentUpdateCommand extends ContentUpdateCommand {
+
+    private final ItemRelease itemRelease;
+
+    public TtsContentUpdateCommand(ItemRelease itemRelease) {
+        this.itemRelease = itemRelease;
+    }
+
+    @Override
+    public String applyEnglishContentUpdate(String englishContentHtml) {
+        Document doc = super.newJsoupDocument(englishContentHtml);
+
+
+        return MapperUtil.removeNewLine(doc.body().html());
+    }
+
+    @Override
+    public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
+        return this.applyEnglishContentUpdate(translatedContent);
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/TtsContentUpdateCommand.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/TtsContentUpdateCommand.java
@@ -1,28 +1,123 @@
 package org.opentestsystem.ap.migration.migration.migration3177;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.jsoup.nodes.Document;
 import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.common.saaif.item.SaaifContent;
 import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LANG_ENU;
+import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LANG_ESN;
+
+@Slf4j
 public class TtsContentUpdateCommand extends ContentUpdateCommand {
 
     private final ItemRelease itemRelease;
+    private final String TTS_ATTRIBUTE = "data-iat-tts";
+    private final String TTS_VI_ATTRIBUTE = "data-iat-tts-vi";
+    private final String LOG_PREFIX = "[TIMS-MISSING-TTS-MIGRATION]";
+    private String itemId;
+    private boolean isStimulus;
 
     public TtsContentUpdateCommand(ItemRelease itemRelease) {
         this.itemRelease = itemRelease;
+        if (Objects.nonNull(itemRelease.getItem())) {
+            this.itemId = itemRelease.getItem().getId();
+            this.isStimulus = false;
+        } else if (Objects.nonNull(itemRelease.getPassage())) {
+            this.itemId = itemRelease.getPassage().getId();
+            this.isStimulus = true;
+        }
     }
 
     @Override
     public String applyEnglishContentUpdate(String englishContentHtml) {
-        Document doc = super.newJsoupDocument(englishContentHtml);
-
-
-        return MapperUtil.removeNewLine(doc.body().html());
+        return addTTSIfNeeded(englishContentHtml, LANG_ENU);
     }
 
     @Override
     public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
-        return this.applyEnglishContentUpdate(translatedContent);
+        return addTTSIfNeeded(translatedContent, LANG_ESN);
     }
+
+    /**
+     * When missing, adds the data-iat-tts attribute and value to an html element
+     *
+     * @param content  Well formed Html
+     * @param language The language where content originated
+     * @return Well formed Html
+     */
+    private String addTTSIfNeeded(String content, String language) {
+        Document doc = super.newJsoupDocument(content);
+        AtomicBoolean ttsUpdated = new AtomicBoolean(false);
+        doc.getElementsByAttribute(TTS_VI_ATTRIBUTE).forEach(element -> {
+            if (!element.hasAttr(TTS_ATTRIBUTE)) {
+                String tts = getTtsValue(element.attr(TTS_VI_ATTRIBUTE), language);
+                if (StringUtils.isNotBlank(tts)) {
+                    ttsUpdated.set(true);
+                    element.attr(TTS_ATTRIBUTE, tts);
+                    log.info(String.format("%s TTS value %s restored to item: %s", LOG_PREFIX, tts, this.itemId));
+                }
+            }
+        });
+        if (ttsUpdated.get()) {
+            content = MapperUtil.removeNewLine(doc.body().html());
+        }
+        return content;
+    }
+
+    /**
+     * Uses the TTS-VI value to Return the TTS value originally provided on the import ItemRelease Xml
+     *
+     * @param ttsVi    Current TTS-VI value
+     * @param language Language where the content originated
+     * @return Originally provided TTS value
+     */
+    private String getTtsValue(String ttsVi, String language) {
+        String ttsValue = "";
+        if (!isStimulus) {
+            Optional<ItemRelease.Item.Content> languageContent = this.itemRelease.getItem().getContent()
+                    .stream()
+                    .filter(content -> language.equals(content.getLanguage()))
+                    .findFirst();
+            if (languageContent.isPresent()) {
+                ttsValue = getTtsValue(languageContent.get(), ttsVi);
+            }
+        } else {
+            Optional<ItemRelease.Passage.Content> languageContent = this.itemRelease.getPassage().getContent()
+                    .stream()
+                    .filter(content -> language.equals(content.getLanguage()))
+                    .findFirst();
+            if (languageContent.isPresent()) {
+                ttsValue = getTtsValue(languageContent.get(), ttsVi);
+            }
+        }
+        return ttsValue;
+    }
+
+    /**
+     * Uses the TTS-VI value to Return the TTS value originally provided on the import ItemRelease Xml
+     *
+     * @param content Well formed Html
+     * @param ttsVi   TTS-VI value
+     * @return Originally provided TTS value
+     */
+    private String getTtsValue(SaaifContent content, String ttsVi) {
+        return content.getApipAccessibility().getAccessibilityInfo()
+                .getAccessElement()
+                .stream()
+                .filter(accessElement -> accessElement.getRelatedElementInfo()
+                        .getBrailleText().getBrailleTextString().equals(ttsVi))
+                .map(accessElement -> accessElement.getRelatedElementInfo()
+                        .getReadAloud().getTextToSpeechPronunciationAlternate())
+                .collect(Collectors.joining());
+    }
+
 }

--- a/src/test/java/org/opentestsystem/ap/migration/TestUtil.java
+++ b/src/test/java/org/opentestsystem/ap/migration/TestUtil.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.opentestsystem.ap.common.model.ModelConstants;
 import org.opentestsystem.ap.common.model.ItemImageResource;
 import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.common.saaif.item.SaaifAccessElement;
 import org.opentestsystem.ap.common.saaif.mapper.model.ImportItem;
 import org.opentestsystem.ap.common.saaif.mapper.model.ItemProps;
 import org.opentestsystem.ap.common.saaif.metadata.SmarterAppMetadata;
@@ -102,5 +103,30 @@ public class TestUtil {
         resource.getProductionFile().setFileName(productionFileName);
 
         return resource;
+    }
+
+    public ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement getNewPassageAccessElement() {
+        ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement accessElement =
+                new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement();
+
+        ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.ContentLinkInfo contentLinkInfo =
+                new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.ContentLinkInfo();
+
+        ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.ReadAloud readAloud =
+                new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.ReadAloud();
+
+        ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo relatedElementInfo =
+                new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo();
+
+        ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.BrailleText brailleText =
+                new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.BrailleText();
+
+        relatedElementInfo.setReadAloud(readAloud);
+        relatedElementInfo.setBrailleText(brailleText);
+
+        accessElement.setContentLinkInfo(contentLinkInfo);
+        accessElement.setRelatedElementInfo(relatedElementInfo);
+
+        return accessElement;
     }
 }

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration1615Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration1615Test.java
@@ -30,6 +30,7 @@ import org.opentestsystem.ap.common.saaif.mapper.model.ItemProps;
 import org.opentestsystem.ap.common.saaif.mapper.model.SkipMigration;
 import org.opentestsystem.ap.common.saaif.mapper.util.MigrationFileUtil;
 import org.opentestsystem.ap.common.saaif.metadata.SmarterAppMetadata;
+import org.opentestsystem.ap.migration.TestUtil;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterFactory;
@@ -70,6 +71,8 @@ public class Migration1615Test {
 
     private Migration1615 migration;
 
+    private TestUtil testUtil;
+
     @Before
     public void setUp() {
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
@@ -79,6 +82,8 @@ public class Migration1615Test {
         migration = new Migration1615(applicationDependencyProvider,
                 applicationProperties, dataManager, eventProducer,
                 dataStoreUtility, dataStoreAttachmentManager);
+
+        testUtil = new TestUtil();
     }
 
     @Test
@@ -400,30 +405,7 @@ public class Migration1615Test {
 
     /********************************************************************/
 
-    private ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement getNewAccessElement() {
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement accessElement =
-                new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement();
 
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.ContentLinkInfo contentLinkInfo =
-                new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.ContentLinkInfo();
-
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.ReadAloud readAloud =
-                new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.ReadAloud();
-
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo relatedElementInfo =
-                new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo();
-
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.BrailleText brailleText =
-                new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement.RelatedElementInfo.BrailleText();
-
-        relatedElementInfo.setReadAloud(readAloud);
-        relatedElementInfo.setBrailleText(brailleText);
-
-        accessElement.setContentLinkInfo(contentLinkInfo);
-        accessElement.setRelatedElementInfo(relatedElementInfo);
-
-        return accessElement;
-    }
 
     private ImportItem getNewImportItem(String enuPrompt) throws IOException {
         ItemRelease itemRelease = new ItemRelease();
@@ -434,14 +416,14 @@ public class Migration1615Test {
         content.setApipAccessibility(new ItemRelease.Item.Content.ApipAccessibility());
         content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo());
 
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = getNewAccessElement();
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = this.testUtil.getNewItemAccessElement();
         textElement.setIdentifier("ae2");
         textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_TAG_3_BEGIN");
         textElement.getContentLinkInfo().setType("Text");
         textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciation("A B C D,");
         textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciationAlternate("ABCD");
 
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement graphicElement = getNewAccessElement();
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement graphicElement = this.testUtil.getNewItemAccessElement();
         graphicElement.setIdentifier("ae4");
         graphicElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_stem");
         graphicElement.getContentLinkInfo().setType("Graphic");

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3177Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3177Test.java
@@ -93,8 +93,6 @@ public class Migration3177Test {
 
         SaItem migratedItem = (SaItem) migratedEntity.getItemJson();
 
-//        System.out.println(migratedItem.getCore().getEn().getPrompt());
-
         assert (migratedItem.getCore().getEn()
                 .getPrompt().contains("data-iat-tts=\"Border collies are my\""));
     }
@@ -116,8 +114,6 @@ public class Migration3177Test {
         ItemEntity migratedEntity = migration.migrateEntity(entity, migrationContext);
 
         StimItem migratedItem = (StimItem) migratedEntity.getItemJson();
-
-//        System.out.println(migratedItem.getCore().getEn().getContent());
 
         assert (migratedItem.getCore().getEn()
                 .getContent().contains("data-iat-tts=\"Border collies are my\""));

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3177Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3177Test.java
@@ -1,0 +1,183 @@
+package org.opentestsystem.ap.migration.migration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
+import org.opentestsystem.ap.common.model.ModelConstants;
+import org.opentestsystem.ap.common.model.SaItem;
+import org.opentestsystem.ap.common.model.StimItem;
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.common.saaif.mapper.model.ImportItem;
+import org.opentestsystem.ap.common.saaif.mapper.model.ItemProps;
+import org.opentestsystem.ap.common.saaif.mapper.util.MigrationFileUtil;
+import org.opentestsystem.ap.common.saaif.metadata.SmarterAppMetadata;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.TestUtil;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterFactory;
+import org.opentestsystem.ap.migration.gitlab.GitLabSyncManager;
+import org.opentestsystem.ap.migration.migration.migration3177.Migration3177;
+import org.opentestsystem.ap.migration.model.MigrationContext;
+import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.ap.common.model.ModelConstants.ItemType.TYPE_SA;
+import static org.opentestsystem.ap.common.model.ModelConstants.ItemType.TYPE_STIM;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Migration3177Test {
+    @Mock
+    private ApplicationProperties applicationProperties;
+
+    @Mock
+    private DataStoreDataManager dataManager;
+
+    @Mock
+    private ItemManagerEventProducer eventProducer;
+
+    @Mock
+    private DataStoreUtility dataStoreUtility;
+
+    @Mock
+    private DataStoreAttachmentManager dataStoreAttachmentManager;
+
+    @Mock
+    private MigrationFileUtil migrationFileUtil;
+
+    @Mock
+    private GitLabSyncManager gitLabSyncManager;
+
+    @Mock
+    private ApplicationDependencyProvider applicationDependencyProvider;
+
+    private Migration3177 migration;
+
+    private TestUtil testUtil;
+
+    @Before
+    public void setUp() {
+        when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
+        when(applicationDependencyProvider.getItemBankSyncManager()).thenReturn(gitLabSyncManager);
+        when(applicationDependencyProvider.getContentUpdaterFactory()).thenReturn(new ContentUpdaterFactory());
+
+        migration = new Migration3177(applicationProperties, dataManager, eventProducer,
+                dataStoreUtility, dataStoreAttachmentManager, applicationDependencyProvider);
+
+        testUtil = new TestUtil();
+    }
+
+    @Test
+    public void shouldUpdateTTSOnSaItem() throws IOException {
+        final String sampleStemContent = "<p><span class=\"iat-text2speech\" data-iat-tts-vi=\"Border collies are my\">Border collies are my</span></p>";
+
+        ItemEntity entity = new ItemEntity("123", "master");
+        SaItem item = new SaItem("123");
+        item.getCore().getEn().setPrompt(sampleStemContent);
+        entity.setItemJson(item);
+
+        ImportItem importItem = getNewImportItem(sampleStemContent, TYPE_SA);
+
+        ApplicationProperties.MigrationDefinition migrationDefinition = new ApplicationProperties.MigrationDefinition();
+        migrationDefinition.setRequiresImportFiles(true);
+        MigrationContext migrationContext = new MigrationContext("", migrationDefinition, importItem);
+        ItemEntity migratedEntity = migration.migrateEntity(entity, migrationContext);
+
+        SaItem migratedItem = (SaItem) migratedEntity.getItemJson();
+
+//        System.out.println(migratedItem.getCore().getEn().getPrompt());
+
+        assert (migratedItem.getCore().getEn()
+                .getPrompt().contains("data-iat-tts=\"Border collies are my\""));
+    }
+
+    @Test
+    public void shouldUpdateTTSOnStimItem() throws IOException {
+        final String sampleStemContent = "<p><span class=\"iat-text2speech\" data-iat-tts-vi=\"Border collies are my\">Border collies are my</span></p>";
+
+        ItemEntity entity = new ItemEntity("123", "master");
+        StimItem item = new StimItem("123");
+        item.getCore().getEn().setContent(sampleStemContent);
+        entity.setItemJson(item);
+
+        ImportItem importItem = getNewImportItem(sampleStemContent, TYPE_STIM);
+
+        ApplicationProperties.MigrationDefinition migrationDefinition = new ApplicationProperties.MigrationDefinition();
+        migrationDefinition.setRequiresImportFiles(true);
+        MigrationContext migrationContext = new MigrationContext("", migrationDefinition, importItem);
+        ItemEntity migratedEntity = migration.migrateEntity(entity, migrationContext);
+
+        StimItem migratedItem = (StimItem) migratedEntity.getItemJson();
+
+//        System.out.println(migratedItem.getCore().getEn().getContent());
+
+        assert (migratedItem.getCore().getEn()
+                .getContent().contains("data-iat-tts=\"Border collies are my\""));
+    }
+
+
+    private ImportItem getNewImportItem(String enuPrompt, String itemType) throws IOException {
+        ItemRelease itemRelease = new ItemRelease();
+
+        if (itemType.equals(TYPE_STIM)) {
+            ItemRelease.Passage passage = new ItemRelease.Passage();
+            ItemRelease.Passage.Content content;
+            content = new ItemRelease.Passage.Content();
+            content.setStem(enuPrompt);
+            content.setLanguage(ModelConstants.ItemLanguage.LANG_ENU);
+            content.setApipAccessibility(new ItemRelease.Passage.Content.ApipAccessibility());
+            content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo());
+            ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = this.testUtil.getNewPassageAccessElement();
+            textElement.setIdentifier("ae2");
+            textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_TAG_3_BEGIN");
+            textElement.getContentLinkInfo().setType("Text");
+            textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciation("");
+            textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciationAlternate("Border collies are my");
+            textElement.getRelatedElementInfo().getBrailleText().setBrailleTextString("Border collies are my");
+            content.getApipAccessibility().getAccessibilityInfo().getAccessElement().add(textElement);
+
+            passage.getContent().add(content);
+            itemRelease.setPassage(passage);
+        } else {
+            ItemRelease.Item item = new ItemRelease.Item();
+            ItemRelease.Item.Content content;
+            content = new ItemRelease.Item.Content();
+            content.setStem(enuPrompt);
+            content.setLanguage(ModelConstants.ItemLanguage.LANG_ENU);
+            content.setApipAccessibility(new ItemRelease.Item.Content.ApipAccessibility());
+            content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo());
+            ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = this.testUtil.getNewItemAccessElement();
+            textElement.setIdentifier("ae2");
+            textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_TAG_3_BEGIN");
+            textElement.getContentLinkInfo().setType("Text");
+            textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciation("");
+            textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciationAlternate("Border collies are my");
+            textElement.getRelatedElementInfo().getBrailleText().setBrailleTextString("Border collies are my");
+            content.getApipAccessibility().getAccessibilityInfo().getAccessElement().add(textElement);
+
+            item.getContent().add(content);
+            itemRelease.setItem(item);
+        }
+
+        ImportItem importItem = new ImportItem();
+        ItemProps itemProps = new ItemProps();
+        SmarterAppMetadata metadata = new SmarterAppMetadata();
+        metadata.setSubject("math");
+
+        importItem.setItemProps(itemProps);
+        importItem.setItemRelease(itemRelease);
+        importItem.setSmarterAppMetadata(metadata);
+        importItem.setExpandedImportItemPath(Files.createTempDirectory("tes"));
+        importItem.setItemImportSourcePath(Files.createTempDirectory("testSrc"));
+
+        return importItem;
+    }
+}


### PR DESCRIPTION
This migration has no blocking edits. It looks at all rich text content on all item types except TUT. It looks all elements that have the `data-iat-tts-vi` attribute, checking for the existence of the `data-iat-tts` element. If it does not exist it looks up the value provided in the import Item Release. It creates the `data-iat-tts` attribute and sets its value.