### PR TITLE
IAT-3221 - Remove invalid duplicate images from item.json

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -74,7 +74,7 @@ migration:
   imrt:
     syncUrlPattern: "http://localhost:9081/sync/%s"
   includedItems:
-    - 200229
+#    - 33413
   data-store-migrations:
     enabled: true
     migrationSets:

--- a/application.yml
+++ b/application.yml
@@ -63,7 +63,7 @@ migration:
   syncFromGitlabEnabled: false
   copySourceToTargetEnabled: false
   deleteItemsEnabled: false
-  validateMigrationSets: true
+  validateMigrationSets: false
   itemFileLocation: ${tims.copy.item.file.location}
   syncWithImrt: false
   sourceBank:
@@ -74,7 +74,7 @@ migration:
   imrt:
     syncUrlPattern: "http://localhost:9081/sync/%s"
   includedItems:
-#    - 33413
+    - 200229
   data-store-migrations:
     enabled: true
     migrationSets:
@@ -507,6 +507,11 @@ migration:
           - migrationName: "migration3177"
             migrationDescription: "IAT-3177: Certain TTS tags were written incorrectly during a recent migration"
             requiresImportFiles: true
+      - migrationSetKey: "iat-42.2"
+        migrationDefinitions:
+          - migrationName: "migration3221"
+            migrationDescription: "IAT-3221: Remove invalid duplicate images from item.json"
+            requiresImportFiles: false
 
 ---
 spring:

--- a/application.yml
+++ b/application.yml
@@ -63,7 +63,7 @@ migration:
   syncFromGitlabEnabled: false
   copySourceToTargetEnabled: false
   deleteItemsEnabled: false
-  validateMigrationSets: false
+  validateMigrationSets: true
   itemFileLocation: ${tims.copy.item.file.location}
   syncWithImrt: false
   sourceBank:

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
@@ -54,9 +55,14 @@ public class Migration3221 extends AbstractMigration {
         List<String> imageFilenames = new ArrayList<>();
         for (ItemImageResource imageResource : imageResources) {
             String prodFileName = imageResource.getProductionFile().getFileName();
-            if (!imageFilenames.contains(prodFileName)) {
-                //TODO: Account for resources where the production file name is null
+            if (prodFileName == null) {
+                // Do not look for duplicates when the production file name is null.
+                // This is a valid state of the image resource.
+                // The defect that caused IAT-3221 populated this value
+                uniqueImageResources.add(imageResource);
+            } else if (!imageFilenames.contains(prodFileName)) {
                 List<ItemImageResource> imageLookup = imageResources.stream()
+                        .filter(resource -> resource.getProductionFile().getFileName() != null)
                         .filter(resource -> resource.getProductionFile().getFileName().equals(prodFileName))
                         .collect(Collectors.toList());
                 if (imageLookup.size() == 1) {

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
@@ -29,8 +29,7 @@ public class Migration3221 extends AbstractMigration {
                          final DataStoreDataManager dataManager,
                          final ItemManagerEventProducer eventProducer,
                          final DataStoreUtility dataStoreUtility,
-                         final DataStoreAttachmentManager dataStoreAttachmentManager,
-                         final AppAssembler appAssembler) {
+                         final DataStoreAttachmentManager dataStoreAttachmentManager) {
         super(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager);
         this.appAssembler = applicationDependencyProvider.getAppAssembler();
     }
@@ -58,6 +57,12 @@ public class Migration3221 extends AbstractMigration {
         return itemEntity;
     }
 
+    /**
+     * Returns unique list of ItemImageResource after checking if resource is referenced in content or as a glossary illustration
+     *
+     * @param item The Item
+     * @return List of ItemImageResource
+     */
     private List<ItemImageResource> filterUniqueImageResources(Item item) {
         // List of unique image resources
         List<ItemImageResource> uniqueImageResources = new ArrayList<>();
@@ -73,48 +78,90 @@ public class Migration3221 extends AbstractMigration {
                 // The defect that caused IAT-3221 populated this value with a file name.
                 uniqueImageResources.add(imageResource);
             } else if (!processedFilenames.contains(prodFileName)) {
-                List<ItemImageResource> resourcesWithSameProdFilename = item.getImages().getImageResources().stream()
-                        .filter(resource -> resource.getProductionFile().getFileName() != null)
-                        .filter(resource -> resource.getProductionFile().getFileName().equals(prodFileName))
-                        .collect(Collectors.toList());
+                List<ItemImageResource> resourcesWithSameProdFilename = getResourcesWithSameProdFileName(item, prodFileName);
                 if (resourcesWithSameProdFilename.size() == 1) {
                     // Keep image resource if there's only one with the production file name
-                    processedFilenames.add(resourcesWithSameProdFilename.get(0).getProductionFile().getFileName());
-                    uniqueImageResources.add(resourcesWithSameProdFilename.get(0));
+                    keepImageResource(uniqueImageResources, processedFilenames, resourcesWithSameProdFilename.get(0));
                 } else {
-                    boolean imageIsReferenced = false;
-                    for (ItemImageResource resource : resourcesWithSameProdFilename) {
-                        // Try to find image resources in item content
-                        if (itemJson.contains(String.format("data-iat-image-resource-id=\"%s\"", resource.getId()))) {
-                            // Keep image resource if it is referenced in content
-                            processedFilenames.add(resource.getProductionFile().getFileName());
-                            uniqueImageResources.add(resource);
-                            imageIsReferenced = true;
-                            break;
-                        } else {
-                            //  Try to find image resource as a glossary illustration
-                            List<GlossaryTerm> referencedTerms = item.getGlossary().getTerms().stream()
-                                    .filter(glossaryTerm -> glossaryTerm.getIllustrationImageResourceId() != null)
-                                    .filter(glossaryTerm -> glossaryTerm.getIllustrationImageResourceId().equals(resource.getId()))
-                                    .collect(Collectors.toList());
-                            if (referencedTerms.size() > 0) {
-                                // Keep image resource if it is referenced as a glossary illustration
-                                processedFilenames.add(resource.getProductionFile().getFileName());
-                                uniqueImageResources.add(resource);
-                                imageIsReferenced = true;
-                                break;
-                            }
-                        }
-                    }
-                    if (!imageIsReferenced) {
+                    // Keep image resource if referenced in content or as a glossary illustration
+                    boolean isImageReferenced
+                            = keepReferencedImageResources(item, itemJson, resourcesWithSameProdFilename, uniqueImageResources, processedFilenames);
+                    if (!isImageReferenced) {
                         // Keep first image resource if it is not referenced in content
-                        processedFilenames.add(resourcesWithSameProdFilename.get(0).getProductionFile().getFileName());
-                        uniqueImageResources.add(resourcesWithSameProdFilename.get(0));
+                        keepImageResource(uniqueImageResources, processedFilenames, resourcesWithSameProdFilename.get(0));
                     }
                 }
             }
         }
         return uniqueImageResources;
+    }
+
+    /**
+     * Returns a list of ItemImageResource that have the same production file name
+     *
+     * @param item         The item
+     * @param prodFileName The file name to check
+     * @return List of ItemImageResources
+     */
+    private List<ItemImageResource> getResourcesWithSameProdFileName(Item item, String prodFileName) {
+        return item.getImages().getImageResources().stream()
+                .filter(resource -> resource.getProductionFile().getFileName() != null)
+                .filter(resource -> resource.getProductionFile().getFileName().equals(prodFileName))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Adds resource and file name to processing lists
+     *
+     * @param uniqueImageResources List of unique image resources
+     * @param processedFilenames   List of processed file names
+     * @param itemImageResource    ItemImageResource to used to retrieve values
+     */
+    private void keepImageResource(List<ItemImageResource> uniqueImageResources, List<String> processedFilenames, ItemImageResource itemImageResource) {
+        processedFilenames.add(itemImageResource.getProductionFile().getFileName());
+        uniqueImageResources.add(itemImageResource);
+    }
+
+    /**
+     * Adds resource and file name to processing lists for image resources referenced in content or as glossary illustrations.
+     *
+     * @param item                          The item
+     * @param itemJson                      The Json representation of the item
+     * @param resourcesWithSameProdFilename List of image resources with the same production file name
+     * @param uniqueImageResources          List of unique image resources
+     * @param processedFilenames            List of processed file names
+     * @return When true indicates at least one resource in resourcesWithSameProdFilename was referenced
+     */
+    private boolean keepReferencedImageResources(Item item,
+                                                 String itemJson,
+                                                 List<ItemImageResource> resourcesWithSameProdFilename,
+                                                 List<ItemImageResource> uniqueImageResources,
+                                                 List<String> processedFilenames) {
+        boolean imageIsReferenced = false;
+        for (ItemImageResource resource : resourcesWithSameProdFilename) {
+            // Try to find image resources in item content
+            if (itemJson.contains(String.format("data-iat-image-resource-id=\"%s\"", resource.getId()))) {
+                // Keep image resource if it is referenced in content
+                processedFilenames.add(resource.getProductionFile().getFileName());
+                uniqueImageResources.add(resource);
+                imageIsReferenced = true;
+                break;
+            } else {
+                //  Try to find image resource as a glossary illustration
+                List<GlossaryTerm> referencedTerms = item.getGlossary().getTerms().stream()
+                        .filter(glossaryTerm -> glossaryTerm.getIllustrationImageResourceId() != null)
+                        .filter(glossaryTerm -> glossaryTerm.getIllustrationImageResourceId().equals(resource.getId()))
+                        .collect(Collectors.toList());
+                if (referencedTerms.size() > 0) {
+                    // Keep image resource if it is referenced as a glossary illustration
+                    processedFilenames.add(resource.getProductionFile().getFileName());
+                    uniqueImageResources.add(resource);
+                    imageIsReferenced = true;
+                    break;
+                }
+            }
+        }
+        return imageIsReferenced;
     }
 
 }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.ap.migration.migration;
 
+import lombok.extern.slf4j.Slf4j;
+import org.opentestsystem.ap.common.assembler.AppAssembler;
 import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
 import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
 import org.opentestsystem.ap.common.datastore.DataStoreUtility;
@@ -7,6 +9,7 @@ import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
 import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
 import org.opentestsystem.ap.common.model.Item;
 import org.opentestsystem.ap.common.model.ItemImageResource;
+import org.opentestsystem.ap.common.model.glossary.GlossaryTerm;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.model.MigrationContext;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
@@ -14,20 +17,22 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Component
 public class Migration3221 extends AbstractMigration {
+    private final AppAssembler appAssembler;
 
-    public Migration3221(ApplicationDependencyProvider applicationDependencyProvider,
-                         ApplicationProperties applicationProperties,
-                         DataStoreDataManager dataManager,
-                         ItemManagerEventProducer eventProducer,
-                         DataStoreUtility dataStoreUtility,
-                         DataStoreAttachmentManager dataStoreAttachmentManager) {
-        super(applicationDependencyProvider, applicationProperties, dataManager, eventProducer,
-                dataStoreUtility, dataStoreAttachmentManager);
+    public Migration3221(final ApplicationDependencyProvider applicationDependencyProvider,
+                         final ApplicationProperties applicationProperties,
+                         final DataStoreDataManager dataManager,
+                         final ItemManagerEventProducer eventProducer,
+                         final DataStoreUtility dataStoreUtility,
+                         final DataStoreAttachmentManager dataStoreAttachmentManager,
+                         final AppAssembler appAssembler) {
+        super(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager);
+        this.appAssembler = applicationDependencyProvider.getAppAssembler();
     }
 
     @Override
@@ -43,38 +48,72 @@ public class Migration3221 extends AbstractMigration {
     private ItemEntity removeDuplicateImageResources(ItemEntity itemEntity) {
         Item item = itemEntity.getItemJson();
         int initialResourceCount = item.getImages().getImageResources().size();
-        List<ItemImageResource> uniqueImageResources = filterUniqueImageResources(item.getImages().getImageResources());
+        log.info(String.format("Migration3221: Item %s initial image resource count: %s", item.getId(), initialResourceCount));
+        List<ItemImageResource> uniqueImageResources = filterUniqueImageResources(item);
         if (uniqueImageResources.size() != initialResourceCount) {
+            log.info(String.format("Migration3221: Updated image resources on Item: %s", item.getId()));
             item.getImages().setImageResources(uniqueImageResources);
         }
+        log.info(String.format("Migration3221: Item %s final image resource count: %s", item.getId(), uniqueImageResources.size()));
         return itemEntity;
     }
 
-    private List<ItemImageResource> filterUniqueImageResources(List<ItemImageResource> imageResources) {
+    private List<ItemImageResource> filterUniqueImageResources(Item item) {
+        // List of unique image resources
         List<ItemImageResource> uniqueImageResources = new ArrayList<>();
-        List<String> imageFilenames = new ArrayList<>();
-        for (ItemImageResource imageResource : imageResources) {
+        // List of unique processed production file names
+        List<String> processedFilenames = new ArrayList<>();
+        // String version of item.json
+        String itemJson = this.appAssembler.getJsonModelAssembler().toStringItem(item);
+        for (ItemImageResource imageResource : item.getImages().getImageResources()) {
             String prodFileName = imageResource.getProductionFile().getFileName();
             if (prodFileName == null) {
                 // Do not look for duplicates when the production file name is null.
                 // This is a valid state of the image resource.
-                // The defect that caused IAT-3221 populated this value
+                // The defect that caused IAT-3221 populated this value with a file name.
                 uniqueImageResources.add(imageResource);
-            } else if (!imageFilenames.contains(prodFileName)) {
-                List<ItemImageResource> imageLookup = imageResources.stream()
+            } else if (!processedFilenames.contains(prodFileName)) {
+                List<ItemImageResource> resourcesWithSameProdFilename = item.getImages().getImageResources().stream()
                         .filter(resource -> resource.getProductionFile().getFileName() != null)
                         .filter(resource -> resource.getProductionFile().getFileName().equals(prodFileName))
                         .collect(Collectors.toList());
-                if (imageLookup.size() == 1) {
-                    imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
-                    uniqueImageResources.add(imageLookup.get(0));
+                if (resourcesWithSameProdFilename.size() == 1) {
+                    // Keep image resource if there's only one with the production file name
+                    processedFilenames.add(resourcesWithSameProdFilename.get(0).getProductionFile().getFileName());
+                    uniqueImageResources.add(resourcesWithSameProdFilename.get(0));
                 } else {
-                    //TODO: Lookup ids in content. Only leave referenced resource
-                    imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
-                    uniqueImageResources.add(imageLookup.get(0));
+                    boolean imageIsReferenced = false;
+                    for (ItemImageResource resource : resourcesWithSameProdFilename) {
+                        // Try to find image resources in item content
+                        if (itemJson.contains(String.format("data-iat-image-resource-id=\"%s\"", resource.getId()))) {
+                            // Keep image resource if it is referenced in content
+                            processedFilenames.add(resource.getProductionFile().getFileName());
+                            uniqueImageResources.add(resource);
+                            imageIsReferenced = true;
+                            break;
+                        } else {
+                            //  Try to find image resource as a glossary illustration
+                            List<GlossaryTerm> referencedTerms = item.getGlossary().getTerms().stream()
+                                    .filter(glossaryTerm -> glossaryTerm.getIllustrationImageResourceId().equals(resource.getId()))
+                                    .collect(Collectors.toList());
+                            if (referencedTerms.size() > 0) {
+                                // Keep image resource if it is referenced as a glossary illustration
+                                processedFilenames.add(resource.getProductionFile().getFileName());
+                                uniqueImageResources.add(resource);
+                                imageIsReferenced = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!imageIsReferenced) {
+                        // Keep first image resource if it is not referenced in content
+                        processedFilenames.add(resourcesWithSameProdFilename.get(0).getProductionFile().getFileName());
+                        uniqueImageResources.add(resourcesWithSameProdFilename.get(0));
+                    }
                 }
             }
         }
         return uniqueImageResources;
     }
+
 }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
@@ -55,17 +55,18 @@ public class Migration3221 extends AbstractMigration {
         for (ItemImageResource imageResource : imageResources) {
             String prodFileName = imageResource.getProductionFile().getFileName();
             if (!imageFilenames.contains(prodFileName)) {
-              List<ItemImageResource> imageLookup = imageResources.stream()
-                      .filter(resource -> resource.getProductionFile().getFileName().equals(prodFileName))
-                      .collect(Collectors.toList());
-              if (imageLookup.size() == 1) {
-                  imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
-                  uniqueImageResources.add(imageLookup.get(0));
-              } else {
-                  //TODO: Lookup ids in content. Only leave referenced resource
-                  imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
-                  uniqueImageResources.add(imageLookup.get(0));
-              }
+                //TODO: Account for resources where the production file name is null
+                List<ItemImageResource> imageLookup = imageResources.stream()
+                        .filter(resource -> resource.getProductionFile().getFileName().equals(prodFileName))
+                        .collect(Collectors.toList());
+                if (imageLookup.size() == 1) {
+                    imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
+                    uniqueImageResources.add(imageLookup.get(0));
+                } else {
+                    //TODO: Lookup ids in content. Only leave referenced resource
+                    imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
+                    uniqueImageResources.add(imageLookup.get(0));
+                }
             }
         }
         return uniqueImageResources;

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
@@ -1,0 +1,73 @@
+package org.opentestsystem.ap.migration.migration;
+
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
+import org.opentestsystem.ap.common.model.Item;
+import org.opentestsystem.ap.common.model.ItemImageResource;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.model.MigrationContext;
+import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class Migration3221 extends AbstractMigration {
+
+    public Migration3221(ApplicationDependencyProvider applicationDependencyProvider,
+                         ApplicationProperties applicationProperties,
+                         DataStoreDataManager dataManager,
+                         ItemManagerEventProducer eventProducer,
+                         DataStoreUtility dataStoreUtility,
+                         DataStoreAttachmentManager dataStoreAttachmentManager) {
+        super(applicationDependencyProvider, applicationProperties, dataManager, eventProducer,
+                dataStoreUtility, dataStoreAttachmentManager);
+    }
+
+    @Override
+    protected ItemEntity migrateEntity(ItemEntity itemEntity, MigrationContext migrationContext) {
+        return removeDuplicateImageResources(itemEntity);
+    }
+
+    @Override
+    protected boolean shouldMigrateBranch(ItemEntity migratedEntity) {
+        return migratedEntity.getItemJson().getImages().getImageResources().size() > 0;
+    }
+
+    private ItemEntity removeDuplicateImageResources(ItemEntity itemEntity) {
+        Item item = itemEntity.getItemJson();
+        int initialResourceCount = item.getImages().getImageResources().size();
+        List<ItemImageResource> uniqueImageResources = filterUniqueImageResources(item.getImages().getImageResources());
+        if (uniqueImageResources.size() != initialResourceCount) {
+            item.getImages().setImageResources(uniqueImageResources);
+        }
+        return itemEntity;
+    }
+
+    private List<ItemImageResource> filterUniqueImageResources(List<ItemImageResource> imageResources) {
+        List<ItemImageResource> uniqueImageResources = new ArrayList<>();
+        List<String> imageFilenames = new ArrayList<>();
+        for (ItemImageResource imageResource : imageResources) {
+            String prodFileName = imageResource.getProductionFile().getFileName();
+            if (!imageFilenames.contains(prodFileName)) {
+              List<ItemImageResource> imageLookup = imageResources.stream()
+                      .filter(resource -> resource.getProductionFile().getFileName().equals(prodFileName))
+                      .collect(Collectors.toList());
+              if (imageLookup.size() == 1) {
+                  imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
+                  uniqueImageResources.add(imageLookup.get(0));
+              } else {
+                  //TODO: Lookup ids in content. Only leave referenced resource
+                  imageFilenames.add(imageLookup.get(0).getProductionFile().getFileName());
+                  uniqueImageResources.add(imageLookup.get(0));
+              }
+            }
+        }
+        return uniqueImageResources;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3221.java
@@ -94,6 +94,7 @@ public class Migration3221 extends AbstractMigration {
                         } else {
                             //  Try to find image resource as a glossary illustration
                             List<GlossaryTerm> referencedTerms = item.getGlossary().getTerms().stream()
+                                    .filter(glossaryTerm -> glossaryTerm.getIllustrationImageResourceId() != null)
                                     .filter(glossaryTerm -> glossaryTerm.getIllustrationImageResourceId().equals(resource.getId()))
                                     .collect(Collectors.toList());
                             if (referencedTerms.size() > 0) {

--- a/src/test/java/org/opentestsystem/ap/migration/TestUtil.java
+++ b/src/test/java/org/opentestsystem/ap/migration/TestUtil.java
@@ -48,7 +48,7 @@ public class TestUtil {
         applicationProperties = new ApplicationProperties();
     }
 
-    public ImportItem getNewImportItem(String enuPrompt) throws IOException {
+    public static ImportItem getNewImportItem(String enuPrompt) throws IOException {
         ItemRelease itemRelease = new ItemRelease();
         ItemRelease.Item item = new ItemRelease.Item();
         ItemRelease.Item.Content content = new ItemRelease.Item.Content();
@@ -72,7 +72,15 @@ public class TestUtil {
         return importItem;
     }
 
-    public ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement getNewItemAccessElement() {
+    public static ItemImageResource newItemImageResource(String id, String productionFileName) {
+        ItemImageResource resource = new ItemImageResource();
+        resource.setId(id);
+        resource.getProductionFile().setFileName(productionFileName);
+
+        return resource;
+    }
+
+    public static ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement getNewItemAccessElement() {
         ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement accessElement =
                 new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement();
 
@@ -97,15 +105,7 @@ public class TestUtil {
         return accessElement;
     }
 
-    public ItemImageResource newItemImageResource(String productionFileName) {
-        ItemImageResource resource = new ItemImageResource();
-        resource.setId("1");
-        resource.getProductionFile().setFileName(productionFileName);
-
-        return resource;
-    }
-
-    public ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement getNewPassageAccessElement() {
+    public static ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement getNewPassageAccessElement() {
         ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement accessElement =
                 new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement();
 

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration1615Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration1615Test.java
@@ -71,8 +71,6 @@ public class Migration1615Test {
 
     private Migration1615 migration;
 
-    private TestUtil testUtil;
-
     @Before
     public void setUp() {
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
@@ -82,8 +80,6 @@ public class Migration1615Test {
         migration = new Migration1615(applicationDependencyProvider,
                 applicationProperties, dataManager, eventProducer,
                 dataStoreUtility, dataStoreAttachmentManager);
-
-        testUtil = new TestUtil();
     }
 
     @Test
@@ -416,14 +412,14 @@ public class Migration1615Test {
         content.setApipAccessibility(new ItemRelease.Item.Content.ApipAccessibility());
         content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo());
 
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = this.testUtil.getNewItemAccessElement();
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = TestUtil.getNewItemAccessElement();
         textElement.setIdentifier("ae2");
         textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_TAG_3_BEGIN");
         textElement.getContentLinkInfo().setType("Text");
         textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciation("A B C D,");
         textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciationAlternate("ABCD");
 
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement graphicElement = this.testUtil.getNewItemAccessElement();
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement graphicElement = TestUtil.getNewItemAccessElement();
         graphicElement.setIdentifier("ae4");
         graphicElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_stem");
         graphicElement.getContentLinkInfo().setType("Graphic");

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration2360Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration2360Test.java
@@ -53,8 +53,6 @@ public class Migration2360Test {
 
     private Migration2360 migration;
 
-    private TestUtil testUtil;
-
     @Before
     public void setUp() {
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
@@ -64,8 +62,6 @@ public class Migration2360Test {
         migration = new Migration2360(applicationDependencyProvider,
                 applicationProperties, dataManager, eventProducer,
                 dataStoreUtility, dataStoreAttachmentManager);
-
-        testUtil = new TestUtil();
     }
 
 
@@ -78,7 +74,7 @@ public class Migration2360Test {
         item.getCore().getEn().setPrompt(sampleStemContent);
         entity.setItemJson(item);
 
-        ImportItem importItem = testUtil.getNewImportItem(sampleStemContent);
+        ImportItem importItem = TestUtil.getNewImportItem(sampleStemContent);
         MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
 
         entity.getItemJson().getCore().getMetadata().setScoringEngine("Automatic with Key");
@@ -107,7 +103,7 @@ public class Migration2360Test {
         item.getCore().getEn().setPrompt(sampleStemContent);
         entity.setItemJson(item);
 
-        ImportItem importItem = testUtil.getNewImportItem(sampleStemContent);
+        ImportItem importItem = TestUtil.getNewImportItem(sampleStemContent);
         MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
         entity.getItemJson().getCore().getMetadata().setScoringEngine("");
         migration.migrateEntity(entity, migrationContext);
@@ -122,7 +118,7 @@ public class Migration2360Test {
         item.getCore().getEn().setPrompt(sampleStemContent);
         entity.setItemJson(item);
 
-        ImportItem importItem = testUtil.getNewImportItem(sampleStemContent);
+        ImportItem importItem = TestUtil.getNewImportItem(sampleStemContent);
         MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
         entity.getItemJson().getCore().getMetadata().setScoringEngine("AutomaticWithRubric");
         migration.migrateEntity(entity, migrationContext);

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration2776Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration2776Test.java
@@ -53,8 +53,6 @@ public class Migration2776Test {
 
     private Migration2776 migration;
 
-    private TestUtil testUtil;
-
     @Before
     public void setUp() {
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
@@ -64,8 +62,6 @@ public class Migration2776Test {
         migration = new Migration2776(applicationDependencyProvider,
                 applicationProperties, dataManager, eventProducer,
                 dataStoreUtility, dataStoreAttachmentManager);
-
-        testUtil = new TestUtil();
     }
 
     @Test
@@ -86,7 +82,7 @@ public class Migration2776Test {
         item.getCore().getEn().setPrompt(sampleStemContent);
         entity.setItemJson(item);
 
-        ImportItem importItem = testUtil.getNewImportItem(sampleStemContent);
+        ImportItem importItem = TestUtil.getNewImportItem(sampleStemContent);
 
         MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
         ItemEntity migratedEntity = migration.migrateEntity(entity, migrationContext);
@@ -118,7 +114,7 @@ public class Migration2776Test {
         item.getCore().getEn().setPrompt(sampleStemContent);
         entity.setItemJson(item);
 
-        ImportItem importItem = testUtil.getNewImportItem(sampleStemContent);
+        ImportItem importItem = TestUtil.getNewImportItem(sampleStemContent);
 
         MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
         migration.migrateEntity(entity, migrationContext);

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration2957Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration2957Test.java
@@ -57,8 +57,6 @@ public class Migration2957Test {
 
     private TtsMapperFactory ttsMapperFactory = new TtsMapperFactory();
 
-    private TestUtil testUtil = new TestUtil();
-
     private Migration2957 migration;
     private ItemRelease itemRelease;
     private ImportItem importItem = new ImportItem();
@@ -95,14 +93,14 @@ public class Migration2957Test {
         content.setApipAccessibility(new ItemRelease.Item.Content.ApipAccessibility());
         content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo());
 
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = testUtil.getNewItemAccessElement();
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = TestUtil.getNewItemAccessElement();
         textElement.setIdentifier("ae7");
         textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_13574_Object1");
         textElement.getContentLinkInfo().setType("Equation");
         textElement.getRelatedElementInfo().getReadAloud().setAudioShortDesc("A B C D");
         textElement.getRelatedElementInfo().getBrailleText().setBrailleTextString("ABCD");
 
-        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement graphicElement = testUtil.getNewItemAccessElement();
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement graphicElement = TestUtil.getNewItemAccessElement();
         graphicElement.setIdentifier("ae4");
         graphicElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_stem");
         graphicElement.getContentLinkInfo().setType("Graphic");
@@ -122,7 +120,7 @@ public class Migration2957Test {
         // Populate itemEntity
         SaItem saItem = new SaItem("123");
         saItem.getCore().getEn().setPrompt("<img title=\"Image Resource 1\" data-iat-image-resource-id=\"1\" src=\"/assets/ckeditor/plugins/iatimage/icons/image-place-01.png\" class=\"place-holder\" />");
-        saItem.getImages().getImageResources().add(testUtil.newItemImageResource("item_13574_v16_Object1_png16malpha.png"));
+        saItem.getImages().getImageResources().add(TestUtil.newItemImageResource("1", "item_13574_v16_Object1_png16malpha.png"));
         ItemEntity entity = new ItemEntity("123", "master");
         entity.setItemJson(saItem);
 

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3177Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3177Test.java
@@ -61,8 +61,6 @@ public class Migration3177Test {
 
     private Migration3177 migration;
 
-    private TestUtil testUtil;
-
     @Before
     public void setUp() {
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
@@ -71,8 +69,6 @@ public class Migration3177Test {
 
         migration = new Migration3177(applicationProperties, dataManager, eventProducer,
                 dataStoreUtility, dataStoreAttachmentManager, applicationDependencyProvider);
-
-        testUtil = new TestUtil();
     }
 
     @Test
@@ -131,7 +127,7 @@ public class Migration3177Test {
             content.setLanguage(ModelConstants.ItemLanguage.LANG_ENU);
             content.setApipAccessibility(new ItemRelease.Passage.Content.ApipAccessibility());
             content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo());
-            ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = this.testUtil.getNewPassageAccessElement();
+            ItemRelease.Passage.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = TestUtil.getNewPassageAccessElement();
             textElement.setIdentifier("ae2");
             textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_TAG_3_BEGIN");
             textElement.getContentLinkInfo().setType("Text");
@@ -150,7 +146,7 @@ public class Migration3177Test {
             content.setLanguage(ModelConstants.ItemLanguage.LANG_ENU);
             content.setApipAccessibility(new ItemRelease.Item.Content.ApipAccessibility());
             content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo());
-            ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = this.testUtil.getNewItemAccessElement();
+            ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = TestUtil.getNewItemAccessElement();
             textElement.setIdentifier("ae2");
             textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_TAG_3_BEGIN");
             textElement.getContentLinkInfo().setType("Text");

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
@@ -1,0 +1,100 @@
+package org.opentestsystem.ap.migration.migration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
+import org.opentestsystem.ap.common.model.ItemImageResource;
+import org.opentestsystem.ap.common.model.MiItem;
+import org.opentestsystem.ap.common.saaif.mapper.util.MigrationFileUtil;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.TestUtil;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterFactory;
+import org.opentestsystem.ap.migration.gitlab.GitLabSyncManager;
+import org.opentestsystem.ap.migration.model.MigrationContext;
+import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Migration3221Test {
+    @Mock
+    private ApplicationProperties applicationProperties;
+
+    @Mock
+    private DataStoreDataManager dataManager;
+
+    @Mock
+    private ItemManagerEventProducer eventProducer;
+
+    @Mock
+    private DataStoreUtility dataStoreUtility;
+
+    @Mock
+    private DataStoreAttachmentManager dataStoreAttachmentManager;
+
+    @Mock
+    private MigrationFileUtil migrationFileUtil;
+
+    @Mock
+    private GitLabSyncManager gitLabSyncManager;
+
+    @Mock
+    private ApplicationDependencyProvider applicationDependencyProvider;
+
+    private Migration3221 migration;
+
+    @Before
+    public void setUp() throws Exception {
+        when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
+        when(applicationDependencyProvider.getItemBankSyncManager()).thenReturn(gitLabSyncManager);
+        when(applicationDependencyProvider.getContentUpdaterFactory()).thenReturn(new ContentUpdaterFactory());
+        migration = new Migration3221(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager);
+    }
+
+    @Test
+    public void shouldRemoveDuplicateImageResources() {
+        MiItem item = new MiItem("1");
+        item.getImages().setImageResources(createDuplicateImageResources());
+        ItemEntity entity = new ItemEntity("1", "master");
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = migration.migrateEntity(entity, mock(MigrationContext.class));
+
+        assertThat(migratedEntity.getItemJson().getImages().getImageResources().size()).isEqualTo(7);
+    }
+
+    private List<ItemImageResource> createDuplicateImageResources() {
+        List<ItemImageResource> resources = new ArrayList<>();
+        int resourceId = 1;
+        resources.addAll(createImageResources(resourceId, "fileName100.svg", 1));
+        resources.addAll(createImageResources(resourceId, "fileName200.svg", 150));
+        resources.addAll(createImageResources(resourceId, "fileName300.svg", 20));
+        resources.addAll(createImageResources(resourceId, "fileName400.svg", 1));
+        resources.addAll(createImageResources(resourceId, "fileName500.svg", 90));
+        resources.addAll(createImageResources(resourceId, "fileName600.svg", 500));
+        resources.addAll(createImageResources(resourceId, "fileName700.svg", 1));
+        return resources;
+    }
+
+    private List<ItemImageResource> createImageResources(int resourceId, String productionFileName, int count) {
+        List<ItemImageResource> resources = new ArrayList<>();
+        for (int i=0; i< count; i++) {
+            resources.add(TestUtil.newItemImageResource(Integer.toString(resourceId), productionFileName));
+            resourceId++;
+        }
+        return resources;
+    }
+
+}

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
@@ -154,6 +154,11 @@ public class Migration3221Test {
         term2.setIllustrationImageResourceId("10");
         terms.add(term2);
 
+        GlossaryTerm term3 = new GlossaryTerm();
+        GlossaryTerm.initialize(term3);
+        term3.setIllustrationImageResourceId(null);
+        terms.add(term3);
+
         return terms;
     }
 

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
@@ -92,7 +92,7 @@ public class Migration3221Test {
             "    }";
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         AppAssembler appAssembler = new AppAssembler(saaifAssembler, jsonModelAssembler, stringAssembler);
 
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
@@ -100,7 +100,7 @@ public class Migration3221Test {
         when(applicationDependencyProvider.getContentUpdaterFactory()).thenReturn(new ContentUpdaterFactory());
         when(applicationDependencyProvider.getAppAssembler()).thenReturn(appAssembler);
         when(appAssembler.getJsonModelAssembler().toStringItem(any())).thenReturn(ITEM_STRING);
-        migration = new Migration3221(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager, appAssembler);
+        migration = new Migration3221(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager);
     }
 
     @Test

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
@@ -72,12 +72,13 @@ public class Migration3221Test {
 
         ItemEntity migratedEntity = migration.migrateEntity(entity, mock(MigrationContext.class));
 
-        assertThat(migratedEntity.getItemJson().getImages().getImageResources().size()).isEqualTo(7);
+        assertThat(migratedEntity.getItemJson().getImages().getImageResources().size()).isEqualTo(10);
     }
 
     private List<ItemImageResource> createDuplicateImageResources() {
         List<ItemImageResource> resources = new ArrayList<>();
         int resourceId = 1;
+        resources.addAll(createImageResources(resourceId, null, 3));
         resources.addAll(createImageResources(resourceId, "fileName100.svg", 1));
         resources.addAll(createImageResources(resourceId, "fileName200.svg", 150));
         resources.addAll(createImageResources(resourceId, "fileName300.svg", 20));

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3221Test.java
@@ -5,14 +5,24 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.common.assembler.AppAssembler;
 import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
 import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
 import org.opentestsystem.ap.common.datastore.DataStoreUtility;
 import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
 import org.opentestsystem.ap.common.management.ItemManagerEventProducer;
 import org.opentestsystem.ap.common.model.ItemImageResource;
+import org.opentestsystem.ap.common.model.JsonModelAssembler;
 import org.opentestsystem.ap.common.model.MiItem;
+import org.opentestsystem.ap.common.model.ModelConstants;
+import org.opentestsystem.ap.common.model.glossary.GlossaryTerm;
+import org.opentestsystem.ap.common.saaif.SaaifAssembler;
+import org.opentestsystem.ap.common.saaif.StringAssembler;
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.common.saaif.mapper.model.ImportItem;
+import org.opentestsystem.ap.common.saaif.mapper.model.ItemProps;
 import org.opentestsystem.ap.common.saaif.mapper.util.MigrationFileUtil;
+import org.opentestsystem.ap.common.saaif.metadata.SmarterAppMetadata;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.TestUtil;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterFactory;
@@ -20,10 +30,12 @@ import org.opentestsystem.ap.migration.gitlab.GitLabSyncManager;
 import org.opentestsystem.ap.migration.model.MigrationContext;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
 
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,22 +65,52 @@ public class Migration3221Test {
     @Mock
     private ApplicationDependencyProvider applicationDependencyProvider;
 
+    @Mock
+    private SaaifAssembler saaifAssembler;
+
+    @Mock
+    private JsonModelAssembler jsonModelAssembler;
+
+    @Mock
+    private StringAssembler stringAssembler;
+
     private Migration3221 migration;
+
+    private String PROMPT = "<p>test test2</p><img class=\"place-holder\" title=\"Image Resource 4\" data-iat-image-resource-id=\"4\" src=\"/assets/ckeditor/plugins/iatimage/icons/image-place-01.png\" />";
+
+    private String ITEM_STRING =
+            "    \"attachments\" : [ ],\n" +
+            "    \"contentUpdateNeeds\" : [ ],\n" +
+            "    \"en\" : {\n" +
+            "      \"exemplarResponses\" : [ ],\n" +
+            "      \"isManagedByIat\" : true,\n" +
+            "      \"isProvided\" : true,\n" +
+            "      \"isRequired\" : \"true\",\n" +
+            "      \"prompt\" : \"" + PROMPT + "\",\n" +
+            "      \"rubrics\" : [ ],\n" +
+            "      \"updatedDate\" : \"2019-09-18T18:22:32.978Z\"\n" +
+            "    }";
 
     @Before
     public void setUp() throws Exception {
+        AppAssembler appAssembler = new AppAssembler(saaifAssembler, jsonModelAssembler, stringAssembler);
+
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
         when(applicationDependencyProvider.getItemBankSyncManager()).thenReturn(gitLabSyncManager);
         when(applicationDependencyProvider.getContentUpdaterFactory()).thenReturn(new ContentUpdaterFactory());
-        migration = new Migration3221(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager);
+        when(applicationDependencyProvider.getAppAssembler()).thenReturn(appAssembler);
+        when(appAssembler.getJsonModelAssembler().toStringItem(any())).thenReturn(ITEM_STRING);
+        migration = new Migration3221(applicationDependencyProvider, applicationProperties, dataManager, eventProducer, dataStoreUtility, dataStoreAttachmentManager, appAssembler);
     }
 
     @Test
-    public void shouldRemoveDuplicateImageResources() {
-        MiItem item = new MiItem("1");
-        item.getImages().setImageResources(createDuplicateImageResources());
+    public void shouldRemoveDuplicateImageResources() throws Exception{
+        MiItem miItem = new MiItem("1");
+        miItem.getImages().setImageResources(createDuplicateImageResources());
+        miItem.getGlossary().setTerms(createGlossaryTerms());
+        miItem.getCore().getEn().setPrompt(PROMPT);
         ItemEntity entity = new ItemEntity("1", "master");
-        entity.setItemJson(item);
+        entity.setItemJson(miItem);
 
         ItemEntity migratedEntity = migration.migrateEntity(entity, mock(MigrationContext.class));
 
@@ -77,25 +119,50 @@ public class Migration3221Test {
 
     private List<ItemImageResource> createDuplicateImageResources() {
         List<ItemImageResource> resources = new ArrayList<>();
-        int resourceId = 1;
-        resources.addAll(createImageResources(resourceId, null, 3));
-        resources.addAll(createImageResources(resourceId, "fileName100.svg", 1));
-        resources.addAll(createImageResources(resourceId, "fileName200.svg", 150));
-        resources.addAll(createImageResources(resourceId, "fileName300.svg", 20));
-        resources.addAll(createImageResources(resourceId, "fileName400.svg", 1));
-        resources.addAll(createImageResources(resourceId, "fileName500.svg", 90));
-        resources.addAll(createImageResources(resourceId, "fileName600.svg", 500));
-        resources.addAll(createImageResources(resourceId, "fileName700.svg", 1));
+        ResourceCount resourceCount = new ResourceCount(1);
+        resources.addAll(createImageResources(resourceCount, null, 3));
+        resources.addAll(createImageResources(resourceCount, "fileName100.svg", 1));
+        resources.addAll(createImageResources(resourceCount, "fileName200.svg", 10));
+        resources.addAll(createImageResources(resourceCount, "fileName300.svg", 20));
+        resources.addAll(createImageResources(resourceCount, "fileName100.svg", 15));
+        resources.addAll(createImageResources(resourceCount, "fileName400.svg", 1));
+        resources.addAll(createImageResources(resourceCount, "fileName500.svg", 90));
+        resources.addAll(createImageResources(resourceCount, "fileName600.svg", 500));
+        resources.addAll(createImageResources(resourceCount, "fileName700.svg", 1));
         return resources;
     }
 
-    private List<ItemImageResource> createImageResources(int resourceId, String productionFileName, int count) {
+    private List<ItemImageResource> createImageResources(ResourceCount resourceCount, String productionFileName, int count) {
         List<ItemImageResource> resources = new ArrayList<>();
         for (int i=0; i< count; i++) {
-            resources.add(TestUtil.newItemImageResource(Integer.toString(resourceId), productionFileName));
-            resourceId++;
+            resources.add(TestUtil.newItemImageResource(Integer.toString(resourceCount.value), productionFileName));
+            resourceCount.value++;
         }
         return resources;
+    }
+
+    private List<GlossaryTerm> createGlossaryTerms() {
+        List<GlossaryTerm> terms = new ArrayList<>();
+
+        GlossaryTerm term1 = new GlossaryTerm();
+        GlossaryTerm.initialize(term1);
+        term1.setIllustrationImageResourceId("2");
+        terms.add(term1);
+
+        GlossaryTerm term2 = new GlossaryTerm();
+        GlossaryTerm.initialize(term2);
+        term2.setIllustrationImageResourceId("10");
+        terms.add(term2);
+
+        return terms;
+    }
+
+    private class ResourceCount {
+        private int value;
+
+        ResourceCount(int value) {
+            this.value = value;
+        }
     }
 
 }


### PR DESCRIPTION
This migration removes duplicate image resources. It uses the `productionFile.fileName` value to determine if an image resource is duplicate. This condition is not allowed via the TIMS UI.
**Logic flow**
* The image resource is retained if the `productionFile.fileName` is null,  This is a normal condition caused when an image resource is created.
* The image resource is retained if the `productionFile.fileName` is not null and it exists just once on the item.
* The image resource is retained if it is referenced in the item content.
* The image resource is retained if it is referenced as a glossary Illustration.
* All  other image resources are removed

**Notes**
* This migration exposed a sorting issue with Image Resources. Image resources are saved alphabetically ordered using the image resource `id` value, which is numeric. The result is that image resources are ordered incorrectly, for example: 1, 100, 1000, 2, 200, 2000, 3, 300, 3000. This issue was not addressed in this fix.
* The TestUtil class was refactored to not require instantiation. All methods are static.