### PR TITLE
WIP - IAT-3270: Some imported items mathml equations display in italics

### DIFF
--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/AbstractContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/AbstractContentUpdater.java
@@ -7,6 +7,8 @@ import org.opentestsystem.ap.common.model.Table;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
 import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LANG_ESN;
@@ -35,14 +37,12 @@ public abstract class AbstractContentUpdater<T extends Item> implements ContentU
     }
 
     protected boolean updateSpanishItemOptions(List<ItemOption> spanishOptions,
-                                            List<ItemOption> englishOptions,
-                                            ContentUpdateCommand updateCommand) {
+                                               List<ItemOption> englishOptions,
+                                               ContentUpdateCommand updateCommand) {
         boolean isContentChanged = false;
         for (int i = 0; i < spanishOptions.size(); ++i) {
-            String previousValue;
             ItemOption english = this.indexOf(englishOptions, i);
             ItemOption spanish = spanishOptions.get(i);
-
             ContentUpdateCommandResult commandResult = updateCommand.applyTranslatedContentUpdate(
                     LANG_ESN,
                     spanish.getRationale(),
@@ -59,38 +59,50 @@ public abstract class AbstractContentUpdater<T extends Item> implements ContentU
         return isContentChanged;
     }
 
-    protected void updateEnglishTable(Table table, ContentUpdateCommand updateCommand, boolean labelsOnly) {
-        table.getColumns().forEach(column ->
-            column.setLabel(updateCommand.applyEnglishContentUpdate(column.getLabel())));
+    protected boolean updateEnglishTable(Table table, ContentUpdateCommand updateCommand, boolean labelsOnly) {
+        AtomicReference<ContentUpdateCommandResult> commandResult = new AtomicReference<>();
+        AtomicBoolean isContentChanged = new AtomicBoolean(false);
+        table.getColumns().forEach(column -> {
+            commandResult.set(updateCommand.applyEnglishContentUpdate(column.getLabel()));
+            column.setLabel(commandResult.get().getUpdatedContent());
+            isContentChanged.set(isContentChanged.get() || commandResult.get().isContentChanged());
+        });
 
         table.getRows().forEach(row -> {
             row.getCells().forEach(cell -> {
                 if (!labelsOnly || cell.isLabel()) {
-                    cell.setValue(updateCommand.applyEnglishContentUpdate((String) cell.getValue()));
+                    commandResult.set(updateCommand.applyEnglishContentUpdate((String) cell.getValue()));
+                    cell.setValue(commandResult.get().getUpdatedContent());
+                    isContentChanged.set(isContentChanged.get() || commandResult.get().isContentChanged());
                 }
             });
         });
+        return isContentChanged.get();
     }
 
-    protected void updateSpanishTableColumns(List<Table.Column> spanishColumns,
-                                             List<Table.Column> englishColumns,
-                                             ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishTableColumns(List<Table.Column> spanishColumns,
+                                                List<Table.Column> englishColumns,
+                                                ContentUpdateCommand updateCommand) {
+        AtomicReference<ContentUpdateCommandResult> commandResult = new AtomicReference<>();
+        AtomicBoolean isContentChanged = new AtomicBoolean(false);
         for (int i = 0; i < spanishColumns.size(); ++i) {
             Table.Column spanishColumn = spanishColumns.get(i);
             Table.Column englishColumn = this.indexOf(englishColumns, i);
-            spanishColumn.setLabel(
-                updateCommand.applyTranslatedContentUpdate(
+            commandResult.set(updateCommand.applyTranslatedContentUpdate(
                     LANG_ESN,
                     spanishColumn.getLabel(),
                     Objects.nonNull(englishColumn) ? englishColumn.getLabel() : StringUtils.EMPTY));
-
+            spanishColumn.setLabel(commandResult.get().getUpdatedContent());
+            isContentChanged.set(isContentChanged.get() || commandResult.get().isContentChanged());
         }
+        return isContentChanged.get();
     }
 
-    protected void updateSpanishTableRows(List<Table.Row> spanishRows,
-                                          List<Table.Row> englishRows,
-                                          ContentUpdateCommand updateCommand,
-                                          boolean labelsOnly) {
+    protected boolean updateSpanishTableRows(List<Table.Row> spanishRows,
+                                             List<Table.Row> englishRows,
+                                             ContentUpdateCommand updateCommand,
+                                             boolean labelsOnly) {
+        boolean isContentChanged = false;
         for (int i = 0; i < spanishRows.size(); ++i) {
             Table.Row spanishRow = spanishRows.get(i);
             Table.Row englishRow = this.indexOf(englishRows, i);
@@ -98,35 +110,47 @@ public abstract class AbstractContentUpdater<T extends Item> implements ContentU
             List<Table.Cell> spanishCells = Objects.nonNull(spanishRow) ? spanishRow.getCells() : emptyList();
             List<Table.Cell> englishCells = Objects.nonNull(englishRow) ? englishRow.getCells() : emptyList();
 
-            this.updateSpanishTableCells(spanishCells, englishCells, updateCommand, labelsOnly);
+            boolean tableCellsChanged = this.updateSpanishTableCells(spanishCells, englishCells, updateCommand, labelsOnly);
+            isContentChanged = isContentChanged || tableCellsChanged;
         }
+        return isContentChanged;
     }
 
-    protected void updateSpanishTableCells(List<Table.Cell> spanishCells,
-                                           List<Table.Cell> englishCells,
-                                           ContentUpdateCommand updateCommand,
-                                           boolean labelsOnly) {
+    protected boolean updateSpanishTableCells(List<Table.Cell> spanishCells,
+                                              List<Table.Cell> englishCells,
+                                              ContentUpdateCommand updateCommand,
+                                              boolean labelsOnly) {
+        AtomicReference<ContentUpdateCommandResult> commandResult = new AtomicReference<>();
+        AtomicBoolean isContentChanged = new AtomicBoolean(false);
         for (int i = 0; i < spanishCells.size(); ++i) {
             Table.Cell spanishCell = spanishCells.get(i);
             if (Objects.nonNull(spanishCell) && (!labelsOnly || spanishCell.isLabel())) {
                 Table.Cell englishCell = this.indexOf(englishCells, i);
-                spanishCell.setValue(
-                    updateCommand.applyTranslatedContentUpdate(
+                commandResult.set(updateCommand.applyTranslatedContentUpdate(
                         LANG_ESN,
                         (String) spanishCell.getValue(),
                         Objects.nonNull(englishCell) ? (String) englishCell.getValue() : StringUtils.EMPTY));
+
+                spanishCell.setValue(commandResult.get().getUpdatedContent());
+                isContentChanged.set(isContentChanged.get() || commandResult.get().isContentChanged());
             }
         }
+        return isContentChanged.get();
     }
 
-    protected void updateSpanishListOfStrings(List<String> spanishList,
-                                              List<String> englishList,
-                                              ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishListOfStrings(List<String> spanishList,
+                                                 List<String> englishList,
+                                                 ContentUpdateCommand updateCommand) {
+        ContentUpdateCommandResult commandResult;
+        boolean isContentChanged = false;
         for (int i = 0; i < spanishList.size(); ++i) {
             String spanish = spanishList.get(i);
             String english = this.indexOf(englishList, i);
-            spanishList.set(i, updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish, english));
+            commandResult = updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish, english);
+            spanishList.set(i, commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
         }
+        return isContentChanged;
     }
 
     protected <R> R indexOf(List<R> list, int i) {

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/AbstractContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/AbstractContentUpdater.java
@@ -15,32 +15,48 @@ public abstract class AbstractContentUpdater<T extends Item> implements ContentU
 
     protected static final boolean LABELS_ONLY = true;
 
-    protected abstract void updateEnglishContent(T item, ContentUpdateCommand contentUpdateCommand);
+    protected boolean contentChanged = false;
 
-    protected abstract void updateSpanishContent(T item, ContentUpdateCommand contentUpdateCommand);
+    protected abstract boolean updateEnglishContent(T item, ContentUpdateCommand contentUpdateCommand);
+
+    protected abstract boolean updateSpanishContent(T item, ContentUpdateCommand contentUpdateCommand);
 
     @Override
     public void updateContent(T item, ContentUpdateCommand contentUpdateCommand) {
-        updateEnglishContent(item, contentUpdateCommand);
-        updateSpanishContent(item, contentUpdateCommand);
+        boolean englishChanged = updateEnglishContent(item, contentUpdateCommand);
+        boolean spanishChanged = updateSpanishContent(item, contentUpdateCommand);
+
+        this.contentChanged = englishChanged || spanishChanged;
     }
 
-    protected void updateSpanishItemOptions(List<ItemOption> spanishOptions,
+    @Override
+    public boolean contentChanged() {
+        return this.contentChanged;
+    }
+
+    protected boolean updateSpanishItemOptions(List<ItemOption> spanishOptions,
                                             List<ItemOption> englishOptions,
                                             ContentUpdateCommand updateCommand) {
+        boolean isContentChanged = false;
         for (int i = 0; i < spanishOptions.size(); ++i) {
+            String previousValue;
             ItemOption english = this.indexOf(englishOptions, i);
             ItemOption spanish = spanishOptions.get(i);
-            spanish.setRationale(
-                updateCommand.applyTranslatedContentUpdate(
+
+            ContentUpdateCommandResult commandResult = updateCommand.applyTranslatedContentUpdate(
                     LANG_ESN,
                     spanish.getRationale(),
-                    Objects.nonNull(english) ? english.getRationale() : StringUtils.EMPTY));
-            spanish.setText(
-                updateCommand.applyTranslatedContentUpdate(
+                    Objects.nonNull(english) ? english.getRationale() : StringUtils.EMPTY);
+            spanish.setRationale(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+            commandResult = updateCommand.applyTranslatedContentUpdate(
                     LANG_ESN, spanish.getText(),
-                    Objects.nonNull(english) ? english.getText() : StringUtils.EMPTY));
+                    Objects.nonNull(english) ? english.getText() : StringUtils.EMPTY);
+            spanish.setText(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
         }
+        return isContentChanged;
     }
 
     protected void updateEnglishTable(Table table, ContentUpdateCommand updateCommand, boolean labelsOnly) {
@@ -115,5 +131,9 @@ public abstract class AbstractContentUpdater<T extends Item> implements ContentU
 
     protected <R> R indexOf(List<R> list, int i) {
         return (Objects.nonNull(list) && i < list.size()) ? list.get(i) : null;
+    }
+
+    protected boolean contentChanged(String previous, String current) {
+        return !previous.equals(current);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdateCommand.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdateCommand.java
@@ -8,9 +8,9 @@ import org.jsoup.nodes.Document;
  */
 public abstract class ContentUpdateCommand {
 
-    public abstract String applyEnglishContentUpdate(String englishContentHtml);
+    public abstract ContentUpdateCommandResult applyEnglishContentUpdate(String englishContentHtml);
 
-    public abstract String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent);
+    public abstract ContentUpdateCommandResult applyTranslatedContentUpdate(String language, String translatedContent, String englishContent);
 
     protected Document newJsoupDocument(String htmlContent) {
         final Document doc = Jsoup.parseBodyFragment(htmlContent);

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdateCommandResult.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdateCommandResult.java
@@ -1,0 +1,13 @@
+package org.opentestsystem.ap.migration.contentupdater;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ContentUpdateCommandResult {
+
+    private boolean contentChanged;
+
+    private String updatedContent;
+}

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdater.java
@@ -7,4 +7,6 @@ import org.opentestsystem.ap.common.model.Item;
  */
 public interface ContentUpdater<T extends Item> {
     void updateContent(T item, ContentUpdateCommand contentUpdateCommand);
+
+    boolean contentChanged();
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdaterContext.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/ContentUpdaterContext.java
@@ -1,0 +1,14 @@
+package org.opentestsystem.ap.migration.contentupdater;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+
+@Data
+@AllArgsConstructor
+public class ContentUpdaterContext {
+
+    private boolean contentChanged;
+
+    private ItemEntity migratedEntity;
+}

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/EbsrContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/EbsrContentUpdater.java
@@ -1,7 +1,10 @@
 package org.opentestsystem.ap.migration.contentupdater;
 
 import org.opentestsystem.ap.common.model.EbsrItem;
+import org.opentestsystem.ap.common.model.ItemOption;
 import org.opentestsystem.ap.common.model.content.EbsrItemContent;
+
+import java.util.List;
 
 import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LANG_ESN;
 
@@ -11,39 +14,74 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class EbsrContentUpdater extends AbstractContentUpdater<EbsrItem> {
 
     @Override
-    protected void updateEnglishContent(EbsrItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(EbsrItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         EbsrItemContent content = item.getCore().getEn();
-        content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
 
-        content.setPartAPrompt(updateCommand.applyEnglishContentUpdate(content.getPartAPrompt()));
-        content.setPartBPrompt(updateCommand.applyEnglishContentUpdate(content.getPartBPrompt()));
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getPrompt());
+        content.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        content.getPartAOptions().forEach(itemOption -> {
-            itemOption.setRationale(updateCommand.applyEnglishContentUpdate(itemOption.getRationale()));
-            itemOption.setText(updateCommand.applyEnglishContentUpdate(itemOption.getText()));
-        });
+        commandResult = updateCommand.applyEnglishContentUpdate(content.getPartAPrompt());
+        content.setPartAPrompt(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        content.getPartBOptions().forEach(itemOption -> {
-            itemOption.setRationale(updateCommand.applyEnglishContentUpdate(itemOption.getRationale()));
-            itemOption.setText(updateCommand.applyEnglishContentUpdate(itemOption.getText()));
-        });
+        commandResult = updateCommand.applyEnglishContentUpdate(content.getPartBPrompt());
+        content.setPartBPrompt(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+        boolean isPartAChanged = applyContentUpdateToOptions(content.getPartAOptions(), updateCommand);
+        isContentChanged = isContentChanged || isPartAChanged;
+
+        boolean isPartBChanged = applyContentUpdateToOptions(content.getPartBOptions(), updateCommand);
+        isContentChanged = isContentChanged || isPartBChanged;
+
+        return isContentChanged;
     }
 
     @Override
-    protected void updateSpanishContent(EbsrItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(EbsrItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         EbsrItemContent english = item.getCore().getEn();
         EbsrItemContent spanish = item.getTranslations().getEsp();
 
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(
-            LANG_ESN, spanish.getPrompt(), english.getPrompt()));
+        ContentUpdateCommandResult commandResult = updateCommand.applyTranslatedContentUpdate(
+                LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        spanish.setPartAPrompt(updateCommand.applyTranslatedContentUpdate(
-            LANG_ESN, spanish.getPartAPrompt(), english.getPartAPrompt()));
+        commandResult = updateCommand.applyTranslatedContentUpdate(
+                LANG_ESN, spanish.getPartAPrompt(), english.getPartAPrompt());
+        spanish.setPartAPrompt(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        spanish.setPartBPrompt(updateCommand.applyTranslatedContentUpdate(
-            LANG_ESN, spanish.getPartBPrompt(), english.getPartBPrompt()));
+        commandResult = updateCommand.applyTranslatedContentUpdate(
+                LANG_ESN, spanish.getPartBPrompt(), english.getPartBPrompt());
+        spanish.setPartBPrompt(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        this.updateSpanishItemOptions(spanish.getPartAOptions(), english.getPartAOptions(), updateCommand);
-        this.updateSpanishItemOptions(spanish.getPartBOptions(), english.getPartBOptions(), updateCommand);
+        boolean partAOptionsChanged = this.updateSpanishItemOptions(spanish.getPartAOptions(), english.getPartAOptions(), updateCommand);
+        isContentChanged = isContentChanged || partAOptionsChanged;
+
+        boolean partBOptionsChanged =this.updateSpanishItemOptions(spanish.getPartBOptions(), english.getPartBOptions(), updateCommand);
+        isContentChanged = isContentChanged || partBOptionsChanged;
+
+        return isContentChanged;
     }
+
+    protected boolean applyContentUpdateToOptions(List<ItemOption> options, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged = false;
+        for (ItemOption itemOption : options) {
+            ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(itemOption.getRationale());
+            itemOption.setRationale(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+            commandResult = updateCommand.applyEnglishContentUpdate(itemOption.getText());
+            itemOption.setText(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+        }
+        return isContentChanged;
+    }
+
+
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/EqContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/EqContentUpdater.java
@@ -8,22 +8,30 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class EqContentUpdater extends AbstractContentUpdater<EqItem> {
 
     protected boolean updateEnglishContent(EqItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         EqItemContent english = item.getCore().getEn();
 
-        english.setPrompt(
-            updateCommand.applyEnglishContentUpdate(english.getPrompt()));
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(english.getPrompt());
+        english.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        item.getCore().getScoring().setRubric(
-            updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+        commandResult = updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric());
+        item.getCore().getScoring().setRubric(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        return true;
+        return isContentChanged;
     }
 
     protected boolean updateSpanishContent(EqItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         EqItemContent english = item.getCore().getEn();
         EqItemContent spanish = item.getTranslations().getEsp();
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
 
-        return true;
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        return isContentChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/EqContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/EqContentUpdater.java
@@ -7,7 +7,7 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 
 public class EqContentUpdater extends AbstractContentUpdater<EqItem> {
 
-    protected void updateEnglishContent(EqItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(EqItem item, ContentUpdateCommand updateCommand) {
         EqItemContent english = item.getCore().getEn();
 
         english.setPrompt(
@@ -15,11 +15,15 @@ public class EqContentUpdater extends AbstractContentUpdater<EqItem> {
 
         item.getCore().getScoring().setRubric(
             updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+
+        return true;
     }
 
-    protected void updateSpanishContent(EqItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(EqItem item, ContentUpdateCommand updateCommand) {
         EqItemContent english = item.getCore().getEn();
         EqItemContent spanish = item.getTranslations().getEsp();
         spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/GiContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/GiContentUpdater.java
@@ -9,13 +9,18 @@ public class GiContentUpdater extends AbstractContentUpdater<GiItem> {
 
     @Override
     protected boolean updateEnglishContent(GiItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         GiItemContent englishContent = item.getCore().getEn();
-        englishContent.setPrompt(updateCommand.applyEnglishContentUpdate(englishContent.getPrompt()));
 
-        item.getCore().getScoring().setRubric(
-            updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(englishContent.getPrompt());
+        englishContent.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        return true;
+        commandResult = updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric());
+        item.getCore().getScoring().setRubric(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+        return isContentChanged;
     }
 
     @Override
@@ -23,14 +28,13 @@ public class GiContentUpdater extends AbstractContentUpdater<GiItem> {
         GiItemContent englishContent = item.getCore().getEn();
         GiItemContent spanishContent = item.getTranslations().getEsp();
 
-        spanishContent.setPrompt(
-            updateCommand.applyTranslatedContentUpdate(
+        ContentUpdateCommandResult commandResult = updateCommand.applyTranslatedContentUpdate(
                 LANG_ESN,
                 spanishContent.getPrompt(),
                 englishContent.getPrompt()
-            )
         );
+        spanishContent.setPrompt(commandResult.getUpdatedContent());
 
-        return true;
+        return commandResult.isContentChanged();
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/GiContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/GiContentUpdater.java
@@ -8,16 +8,18 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class GiContentUpdater extends AbstractContentUpdater<GiItem> {
 
     @Override
-    protected void updateEnglishContent(GiItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(GiItem item, ContentUpdateCommand updateCommand) {
         GiItemContent englishContent = item.getCore().getEn();
         englishContent.setPrompt(updateCommand.applyEnglishContentUpdate(englishContent.getPrompt()));
 
         item.getCore().getScoring().setRubric(
             updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(GiItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(GiItem item, ContentUpdateCommand updateCommand) {
         GiItemContent englishContent = item.getCore().getEn();
         GiItemContent spanishContent = item.getTranslations().getEsp();
 
@@ -28,5 +30,7 @@ public class GiContentUpdater extends AbstractContentUpdater<GiItem> {
                 englishContent.getPrompt()
             )
         );
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqoContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqoContentUpdater.java
@@ -10,17 +10,19 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class HtqoContentUpdater extends AbstractContentUpdater<HtqoItem> {
 
     @Override
-    protected void updateEnglishContent(HtqoItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(HtqoItem item, ContentUpdateCommand updateCommand) {
         HtqoItemContent englishContent = item.getCore().getEn();
         englishContent.setPrompt(updateCommand.applyEnglishContentUpdate(englishContent.getPrompt()));
         englishContent.getHtqOrderable().getOrderableStrings().replaceAll(updateCommand::applyEnglishContentUpdate);
 
         item.getCore().getScoring().setRubric(
             updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(HtqoItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(HtqoItem item, ContentUpdateCommand updateCommand) {
         HtqoItemContent englishContent = item.getCore().getEn();
         HtqoItemContent spanishContent = item.getTranslations().getEsp();
 
@@ -36,6 +38,8 @@ public class HtqoContentUpdater extends AbstractContentUpdater<HtqoItem> {
             spanishContent.getHtqOrderable().getOrderableStrings(),
             englishContent.getHtqOrderable().getOrderableStrings(),
             updateCommand);
+
+        return true;
     }
 
     private void updateSpanishOrderables(List<String> spanishOrderables,

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqoContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqoContentUpdater.java
@@ -3,6 +3,7 @@ package org.opentestsystem.ap.migration.contentupdater;
 import org.opentestsystem.ap.common.model.HtqoItem;
 import org.opentestsystem.ap.common.model.content.HtqoItemContent;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LANG_ESN;
@@ -11,44 +12,63 @@ public class HtqoContentUpdater extends AbstractContentUpdater<HtqoItem> {
 
     @Override
     protected boolean updateEnglishContent(HtqoItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         HtqoItemContent englishContent = item.getCore().getEn();
-        englishContent.setPrompt(updateCommand.applyEnglishContentUpdate(englishContent.getPrompt()));
-        englishContent.getHtqOrderable().getOrderableStrings().replaceAll(updateCommand::applyEnglishContentUpdate);
 
-        item.getCore().getScoring().setRubric(
-            updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(englishContent.getPrompt());
+        englishContent.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        return true;
+        for (int i = 0; i < englishContent.getHtqOrderable().getOrderableStrings().size(); ++i) {
+            String orderableValue = englishContent.getHtqOrderable().getOrderableStrings().get(i);
+            commandResult = updateCommand.applyEnglishContentUpdate(orderableValue);
+            englishContent.getHtqOrderable().getOrderableStrings().set(i, commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+        }
+
+        commandResult = updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric());
+        item.getCore().getScoring().setRubric(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+        return isContentChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(HtqoItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         HtqoItemContent englishContent = item.getCore().getEn();
         HtqoItemContent spanishContent = item.getTranslations().getEsp();
 
-        spanishContent.setPrompt(
-            updateCommand.applyTranslatedContentUpdate(
+        ContentUpdateCommandResult commandResult = updateCommand.applyTranslatedContentUpdate(
                 LANG_ESN,
                 spanishContent.getPrompt(),
                 englishContent.getPrompt()
-            )
         );
+        spanishContent.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        updateSpanishOrderables(
-            spanishContent.getHtqOrderable().getOrderableStrings(),
-            englishContent.getHtqOrderable().getOrderableStrings(),
-            updateCommand);
+        boolean spanishOrderablesChanged = updateSpanishOrderables(
+                spanishContent.getHtqOrderable().getOrderableStrings(),
+                englishContent.getHtqOrderable().getOrderableStrings(),
+                updateCommand);
+        isContentChanged = isContentChanged || spanishOrderablesChanged;
 
-        return true;
+        return isContentChanged;
     }
 
-    private void updateSpanishOrderables(List<String> spanishOrderables,
+    private boolean updateSpanishOrderables(List<String> spanishOrderables,
                                          List<String> englishOrderables,
                                          ContentUpdateCommand updateCommand) {
+        boolean isContentChanged = false;
+        ContentUpdateCommandResult commandResult;
         for (int i = 0; i < spanishOrderables.size(); ++i) {
             String english = this.indexOf(englishOrderables, i);
             String spanish = spanishOrderables.get(i);
-            spanishOrderables.set(i, updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish, english));
+
+            commandResult = updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish, english);
+            spanishOrderables.set(i, commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
         }
+        return isContentChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqsContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqsContentUpdater.java
@@ -8,7 +8,7 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class HtqsContentUpdater extends AbstractContentUpdater<HtqsItem> {
 
     @Override
-    protected void updateEnglishContent(HtqsItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(HtqsItem item, ContentUpdateCommand updateCommand) {
         HtqsItemContent englishContent = item.getCore().getEn();
         englishContent.setPrompt(updateCommand.applyEnglishContentUpdate(englishContent.getPrompt()));
         englishContent.getHtqSelectable().setInteractiveText(
@@ -17,10 +17,12 @@ public class HtqsContentUpdater extends AbstractContentUpdater<HtqsItem> {
 
         item.getCore().getScoring().setRubric(
             updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(HtqsItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(HtqsItem item, ContentUpdateCommand updateCommand) {
         HtqsItemContent englishContent = item.getCore().getEn();
         HtqsItemContent spanishContent = item.getTranslations().getEsp();
 
@@ -38,5 +40,7 @@ public class HtqsContentUpdater extends AbstractContentUpdater<HtqsItem> {
                 spanishContent.getHtqSelectable().getInteractiveText(),
                 englishContent.getHtqSelectable().getInteractiveText())
         );
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqsContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/HtqsContentUpdater.java
@@ -9,38 +9,44 @@ public class HtqsContentUpdater extends AbstractContentUpdater<HtqsItem> {
 
     @Override
     protected boolean updateEnglishContent(HtqsItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         HtqsItemContent englishContent = item.getCore().getEn();
-        englishContent.setPrompt(updateCommand.applyEnglishContentUpdate(englishContent.getPrompt()));
-        englishContent.getHtqSelectable().setInteractiveText(
-            updateCommand.applyEnglishContentUpdate(englishContent.getHtqSelectable().getInteractiveText())
-        );
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(englishContent.getPrompt());
+        englishContent.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        item.getCore().getScoring().setRubric(
-            updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+        commandResult = updateCommand.applyEnglishContentUpdate(englishContent.getHtqSelectable().getInteractiveText());
+        englishContent.getHtqSelectable().setInteractiveText(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        return true;
+        commandResult = updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric());
+        item.getCore().getScoring().setRubric(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+        return isContentChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(HtqsItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         HtqsItemContent englishContent = item.getCore().getEn();
         HtqsItemContent spanishContent = item.getTranslations().getEsp();
 
-        spanishContent.setPrompt(
-            updateCommand.applyTranslatedContentUpdate(
+        ContentUpdateCommandResult commandResult = updateCommand.applyTranslatedContentUpdate(
                 LANG_ESN,
                 spanishContent.getPrompt(),
                 englishContent.getPrompt()
-            )
         );
+        spanishContent.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        spanishContent.getHtqSelectable().setInteractiveText(
-            updateCommand.applyTranslatedContentUpdate(
+        commandResult = updateCommand.applyTranslatedContentUpdate(
                 LANG_ESN,
                 spanishContent.getHtqSelectable().getInteractiveText(),
-                englishContent.getHtqSelectable().getInteractiveText())
-        );
+                englishContent.getHtqSelectable().getInteractiveText());
+        spanishContent.getHtqSelectable().setInteractiveText(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        return true;
+        return isContentChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/McContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/McContentUpdater.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.ap.migration.contentupdater;
 
+import org.opentestsystem.ap.common.model.ItemOption;
 import org.opentestsystem.ap.common.model.McItem;
 import org.opentestsystem.ap.common.model.content.McItemContent;
 
@@ -9,23 +10,39 @@ public class McContentUpdater extends AbstractContentUpdater<McItem> {
 
     @Override
     protected boolean updateEnglishContent(McItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         McItemContent content = item.getCore().getEn();
-        content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
-        content.getOptions().forEach(itemOption -> {
-            itemOption.setRationale(updateCommand.applyEnglishContentUpdate(itemOption.getRationale()));
-            itemOption.setText(updateCommand.applyEnglishContentUpdate(itemOption.getText()));
-        });
 
-        return true;
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getPrompt());
+        content.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        for (ItemOption itemOption : content.getOptions()) {
+            commandResult = updateCommand.applyEnglishContentUpdate(itemOption.getRationale());
+            itemOption.setRationale(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+            commandResult = updateCommand.applyEnglishContentUpdate(itemOption.getText());
+            itemOption.setText(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+        }
+
+        return isContentChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(McItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         McItemContent english = item.getCore().getEn();
         McItemContent spanish = item.getTranslations().getEsp();
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
-        this.updateSpanishItemOptions(spanish.getOptions(), english.getOptions(), updateCommand);
 
-        return true;
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        boolean optionsChanged = this.updateSpanishItemOptions(spanish.getOptions(), english.getOptions(), updateCommand);
+
+        return isContentChanged || optionsChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/McContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/McContentUpdater.java
@@ -8,20 +8,24 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class McContentUpdater extends AbstractContentUpdater<McItem> {
 
     @Override
-    protected void updateEnglishContent(McItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(McItem item, ContentUpdateCommand updateCommand) {
         McItemContent content = item.getCore().getEn();
         content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
         content.getOptions().forEach(itemOption -> {
             itemOption.setRationale(updateCommand.applyEnglishContentUpdate(itemOption.getRationale()));
             itemOption.setText(updateCommand.applyEnglishContentUpdate(itemOption.getText()));
         });
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(McItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(McItem item, ContentUpdateCommand updateCommand) {
         McItemContent english = item.getCore().getEn();
         McItemContent spanish = item.getTranslations().getEsp();
         spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
         this.updateSpanishItemOptions(spanish.getOptions(), english.getOptions(), updateCommand);
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/MiContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/MiContentUpdater.java
@@ -8,14 +8,16 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class MiContentUpdater extends AbstractContentUpdater<MiItem> {
 
     @Override
-    protected void updateEnglishContent(MiItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(MiItem item, ContentUpdateCommand updateCommand) {
         MiItemContent content = item.getCore().getEn();
         content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
         this.updateEnglishTable(content.getTable(), updateCommand, LABELS_ONLY);
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(MiItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(MiItem item, ContentUpdateCommand updateCommand) {
         MiItemContent english = item.getCore().getEn();
         MiItemContent spanish = item.getTranslations().getEsp();
 
@@ -26,5 +28,7 @@ public class MiContentUpdater extends AbstractContentUpdater<MiItem> {
 
         this.updateSpanishTableRows(
             spanish.getTable().getRows(), english.getTable().getRows(), updateCommand, LABELS_ONLY);
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/MiContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/MiContentUpdater.java
@@ -9,26 +9,37 @@ public class MiContentUpdater extends AbstractContentUpdater<MiItem> {
 
     @Override
     protected boolean updateEnglishContent(MiItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         MiItemContent content = item.getCore().getEn();
-        content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
-        this.updateEnglishTable(content.getTable(), updateCommand, LABELS_ONLY);
 
-        return true;
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getPrompt());
+        content.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        boolean tableChanged = this.updateEnglishTable(content.getTable(), updateCommand, LABELS_ONLY);
+
+        return isContentChanged || tableChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(MiItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         MiItemContent english = item.getCore().getEn();
         MiItemContent spanish = item.getTranslations().getEsp();
 
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        this.updateSpanishTableColumns(
+        boolean columnsChanged = this.updateSpanishTableColumns(
             spanish.getTable().getColumns(), english.getTable().getColumns(), updateCommand);
+        isContentChanged = isContentChanged || columnsChanged;
 
-        this.updateSpanishTableRows(
+        boolean rowsChanged = this.updateSpanishTableRows(
             spanish.getTable().getRows(), english.getTable().getRows(), updateCommand, LABELS_ONLY);
+        isContentChanged = isContentChanged || rowsChanged;
 
-        return true;
+        return isContentChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/MsContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/MsContentUpdater.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.ap.migration.contentupdater;
 
+import org.opentestsystem.ap.common.model.ItemOption;
 import org.opentestsystem.ap.common.model.MsItem;
 import org.opentestsystem.ap.common.model.content.MsItemContent;
 
@@ -9,23 +10,39 @@ public class MsContentUpdater extends AbstractContentUpdater<MsItem> {
 
     @Override
     protected boolean updateEnglishContent(MsItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         MsItemContent content = item.getCore().getEn();
-        content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
-        content.getOptions().forEach(itemOption -> {
-            itemOption.setRationale(updateCommand.applyEnglishContentUpdate(itemOption.getRationale()));
-            itemOption.setText(updateCommand.applyEnglishContentUpdate(itemOption.getText()));
-        });
 
-        return true;
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getPrompt());
+        content.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        for (ItemOption itemOption : content.getOptions()) {
+            commandResult = updateCommand.applyEnglishContentUpdate(itemOption.getRationale());
+            itemOption.setRationale(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+            commandResult = updateCommand.applyEnglishContentUpdate(itemOption.getText());
+            itemOption.setText(commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+        }
+
+        return isContentChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(MsItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         MsItemContent english = item.getCore().getEn();
         MsItemContent spanish = item.getTranslations().getEsp();
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
-        this.updateSpanishItemOptions(spanish.getOptions(), english.getOptions(), updateCommand);
 
-        return true;
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        boolean optionsChanged = this.updateSpanishItemOptions(spanish.getOptions(), english.getOptions(), updateCommand);
+
+        return isContentChanged || optionsChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/MsContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/MsContentUpdater.java
@@ -8,20 +8,24 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class MsContentUpdater extends AbstractContentUpdater<MsItem> {
 
     @Override
-    protected void updateEnglishContent(MsItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(MsItem item, ContentUpdateCommand updateCommand) {
         MsItemContent content = item.getCore().getEn();
         content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
         content.getOptions().forEach(itemOption -> {
             itemOption.setRationale(updateCommand.applyEnglishContentUpdate(itemOption.getRationale()));
             itemOption.setText(updateCommand.applyEnglishContentUpdate(itemOption.getText()));
         });
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(MsItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(MsItem item, ContentUpdateCommand updateCommand) {
         MsItemContent english = item.getCore().getEn();
         MsItemContent spanish = item.getTranslations().getEsp();
         spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
         this.updateSpanishItemOptions(spanish.getOptions(), english.getOptions(), updateCommand);
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/SaContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/SaContentUpdater.java
@@ -8,15 +8,17 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class SaContentUpdater extends AbstractContentUpdater<SaItem> {
 
     @Override
-    protected void updateEnglishContent(SaItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(SaItem item, ContentUpdateCommand updateCommand) {
         SaItemContent content = item.getCore().getEn();
         content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
         content.getRubrics().replaceAll(updateCommand::applyEnglishContentUpdate);
         content.getExemplarResponses().replaceAll(updateCommand::applyEnglishContentUpdate);
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(SaItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(SaItem item, ContentUpdateCommand updateCommand) {
         SaItemContent english = item.getCore().getEn();
         SaItemContent spanish = item.getTranslations().getEsp();
 
@@ -26,6 +28,8 @@ public class SaContentUpdater extends AbstractContentUpdater<SaItem> {
 
         this.updateSpanishListOfStrings(
             spanish.getExemplarResponses(), english.getExemplarResponses(), updateCommand);
+
+        return true;
     }
 }
 

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/SaContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/SaContentUpdater.java
@@ -9,27 +9,48 @@ public class SaContentUpdater extends AbstractContentUpdater<SaItem> {
 
     @Override
     protected boolean updateEnglishContent(SaItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         SaItemContent content = item.getCore().getEn();
-        content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
-        content.getRubrics().replaceAll(updateCommand::applyEnglishContentUpdate);
-        content.getExemplarResponses().replaceAll(updateCommand::applyEnglishContentUpdate);
 
-        return true;
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getPrompt());
+        content.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        for (int i = 0; i < content.getRubrics().size(); i++) {
+            commandResult = updateCommand.applyEnglishContentUpdate(content.getRubrics().get(i));
+            content.getRubrics().set(i, commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+        }
+
+        for (int i = 0; i < content.getExemplarResponses().size(); i++) {
+            commandResult = updateCommand.applyEnglishContentUpdate(content.getExemplarResponses().get(i));
+            content.getExemplarResponses().set(i, commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+        }
+
+        return isContentChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(SaItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         SaItemContent english = item.getCore().getEn();
         SaItemContent spanish = item.getTranslations().getEsp();
 
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        this.updateSpanishListOfStrings(spanish.getRubrics(), english.getRubrics(), updateCommand);
+        boolean rubricsChanged = this.updateSpanishListOfStrings(
+                spanish.getRubrics(), english.getRubrics(), updateCommand);
+        isContentChanged = isContentChanged || rubricsChanged;
 
-        this.updateSpanishListOfStrings(
-            spanish.getExemplarResponses(), english.getExemplarResponses(), updateCommand);
+        boolean exemplarChanged =  this.updateSpanishListOfStrings(
+                spanish.getExemplarResponses(), english.getExemplarResponses(), updateCommand);
+        isContentChanged = isContentChanged || exemplarChanged;
 
-        return true;
+        return isContentChanged;
     }
 }
 

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/StimContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/StimContentUpdater.java
@@ -10,17 +10,22 @@ public class StimContentUpdater extends AbstractContentUpdater<StimItem> {
     @Override
     protected boolean updateEnglishContent(StimItem item, ContentUpdateCommand updateCommand) {
         StimItemContent content = item.getCore().getEn();
-        content.setContent(updateCommand.applyEnglishContentUpdate(content.getContent()));
 
-        return true;
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getContent());
+        content.setContent(commandResult.getUpdatedContent());
+
+        return commandResult.isContentChanged();
     }
 
     @Override
     protected boolean updateSpanishContent(StimItem item, ContentUpdateCommand updateCommand) {
         StimItemContent english = item.getCore().getEn();
         StimItemContent spanish = item.getTranslations().getEsp();
-        spanish.setContent(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getContent(), english.getContent()));
 
-        return true;
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getContent(), english.getContent());
+        spanish.setContent(commandResult.getUpdatedContent());
+
+        return commandResult.isContentChanged();
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/StimContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/StimContentUpdater.java
@@ -8,15 +8,19 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class StimContentUpdater extends AbstractContentUpdater<StimItem> {
 
     @Override
-    protected void updateEnglishContent(StimItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(StimItem item, ContentUpdateCommand updateCommand) {
         StimItemContent content = item.getCore().getEn();
         content.setContent(updateCommand.applyEnglishContentUpdate(content.getContent()));
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(StimItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(StimItem item, ContentUpdateCommand updateCommand) {
         StimItemContent english = item.getCore().getEn();
         StimItemContent spanish = item.getTranslations().getEsp();
         spanish.setContent(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getContent(), english.getContent()));
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/TiContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/TiContentUpdater.java
@@ -8,7 +8,7 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class TiContentUpdater extends AbstractContentUpdater<TiItem> {
 
     @Override
-    protected void updateEnglishContent(TiItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(TiItem item, ContentUpdateCommand updateCommand) {
         TiItemContent content = item.getCore().getEn();
 
         content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
@@ -18,10 +18,12 @@ public class TiContentUpdater extends AbstractContentUpdater<TiItem> {
             updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
 
         this.updateEnglishTable(content.getTable(), updateCommand, !LABELS_ONLY);
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(TiItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(TiItem item, ContentUpdateCommand updateCommand) {
         TiItemContent english = item.getCore().getEn();
         TiItemContent spanish = item.getTranslations().getEsp();
 
@@ -38,5 +40,7 @@ public class TiContentUpdater extends AbstractContentUpdater<TiItem> {
 
         this.updateSpanishTableRows(
             spanish.getTable().getRows(), english.getTable().getRows(), updateCommand, !LABELS_ONLY);
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/TiContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/TiContentUpdater.java
@@ -9,38 +9,50 @@ public class TiContentUpdater extends AbstractContentUpdater<TiItem> {
 
     @Override
     protected boolean updateEnglishContent(TiItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         TiItemContent content = item.getCore().getEn();
 
-        content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
-        content.getTable().setTitle(updateCommand.applyEnglishContentUpdate(content.getTable().getTitle()));
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getPrompt());
+        content.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        item.getCore().getScoring().setRubric(
-            updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric()));
+        commandResult = updateCommand.applyEnglishContentUpdate(content.getTable().getTitle());
+        content.getTable().setTitle(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        this.updateEnglishTable(content.getTable(), updateCommand, !LABELS_ONLY);
+        commandResult = updateCommand.applyEnglishContentUpdate(item.getCore().getScoring().getRubric());
+        item.getCore().getScoring().setRubric(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        return true;
+        boolean tableChanged = this.updateEnglishTable(content.getTable(), updateCommand, !LABELS_ONLY);
+
+        return isContentChanged || tableChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(TiItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         TiItemContent english = item.getCore().getEn();
         TiItemContent spanish = item.getTranslations().getEsp();
 
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        spanish.getTable().setTitle(
-            updateCommand.applyTranslatedContentUpdate(
+        commandResult = updateCommand.applyTranslatedContentUpdate(
                 LANG_ESN,
                 spanish.getTable().getTitle(),
-                english.getTable().getTitle()));
+                english.getTable().getTitle());
+        spanish.getTable().setTitle(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        this.updateSpanishTableColumns(
-            spanish.getTable().getColumns(), english.getTable().getColumns(), updateCommand);
+        boolean columnsChanged = this.updateSpanishTableColumns(
+                spanish.getTable().getColumns(), english.getTable().getColumns(), updateCommand);
 
-        this.updateSpanishTableRows(
-            spanish.getTable().getRows(), english.getTable().getRows(), updateCommand, !LABELS_ONLY);
+        boolean rowsChanged = this.updateSpanishTableRows(
+                spanish.getTable().getRows(), english.getTable().getRows(), updateCommand, !LABELS_ONLY);
 
-        return true;
+        return isContentChanged || columnsChanged || rowsChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/TutContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/TutContentUpdater.java
@@ -8,14 +8,18 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class TutContentUpdater extends AbstractContentUpdater<TutItem> {
 
     @Override
-    protected void updateEnglishContent(TutItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(TutItem item, ContentUpdateCommand updateCommand) {
         TutItemContent content = item.getCore().getEn();
         content.setContent(updateCommand.applyEnglishContentUpdate(content.getContent()));
+
+        return true;
     }
 
-    protected void updateSpanishContent(TutItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(TutItem item, ContentUpdateCommand updateCommand) {
         TutItemContent english = item.getCore().getEn();
         TutItemContent spanish = item.getTranslations().getEsp();
         spanish.setContent(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getContent(), english.getContent()));
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/TutContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/TutContentUpdater.java
@@ -10,16 +10,21 @@ public class TutContentUpdater extends AbstractContentUpdater<TutItem> {
     @Override
     protected boolean updateEnglishContent(TutItem item, ContentUpdateCommand updateCommand) {
         TutItemContent content = item.getCore().getEn();
-        content.setContent(updateCommand.applyEnglishContentUpdate(content.getContent()));
 
-        return true;
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getContent());
+        content.setContent(commandResult.getUpdatedContent());
+
+        return commandResult.isContentChanged();
     }
 
     protected boolean updateSpanishContent(TutItem item, ContentUpdateCommand updateCommand) {
         TutItemContent english = item.getCore().getEn();
         TutItemContent spanish = item.getTranslations().getEsp();
-        spanish.setContent(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getContent(), english.getContent()));
 
-        return true;
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getContent(), english.getContent());
+        spanish.setContent(commandResult.getUpdatedContent());
+
+        return commandResult.isContentChanged();
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/WerContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/WerContentUpdater.java
@@ -8,15 +8,17 @@ import static org.opentestsystem.ap.common.model.ModelConstants.ItemLanguage.LAN
 public class WerContentUpdater extends AbstractContentUpdater<WerItem> {
 
     @Override
-    protected void updateEnglishContent(WerItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateEnglishContent(WerItem item, ContentUpdateCommand updateCommand) {
         WerItemContent content = item.getCore().getEn();
         content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
         content.setRubric(updateCommand.applyEnglishContentUpdate(content.getRubric()));
         content.getExemplarResponses().replaceAll(updateCommand::applyEnglishContentUpdate);
+
+        return true;
     }
 
     @Override
-    protected void updateSpanishContent(WerItem item, ContentUpdateCommand updateCommand) {
+    protected boolean updateSpanishContent(WerItem item, ContentUpdateCommand updateCommand) {
         WerItemContent english = item.getCore().getEn();
         WerItemContent spanish = item.getTranslations().getEsp();
 
@@ -25,5 +27,7 @@ public class WerContentUpdater extends AbstractContentUpdater<WerItem> {
 
         this.updateSpanishListOfStrings(
             spanish.getExemplarResponses(), english.getExemplarResponses(), updateCommand);
+
+        return true;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/contentupdater/WerContentUpdater.java
+++ b/src/main/java/org/opentestsystem/ap/migration/contentupdater/WerContentUpdater.java
@@ -9,25 +9,44 @@ public class WerContentUpdater extends AbstractContentUpdater<WerItem> {
 
     @Override
     protected boolean updateEnglishContent(WerItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         WerItemContent content = item.getCore().getEn();
-        content.setPrompt(updateCommand.applyEnglishContentUpdate(content.getPrompt()));
-        content.setRubric(updateCommand.applyEnglishContentUpdate(content.getRubric()));
-        content.getExemplarResponses().replaceAll(updateCommand::applyEnglishContentUpdate);
 
-        return true;
+        ContentUpdateCommandResult commandResult = updateCommand.applyEnglishContentUpdate(content.getPrompt());
+        content.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
+
+        commandResult = updateCommand.applyEnglishContentUpdate(content.getRubric());
+        content.setRubric(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
+
+        for (int i = 0; i < content.getExemplarResponses().size(); i++) {
+            commandResult = updateCommand.applyEnglishContentUpdate(content.getExemplarResponses().get(i));
+            content.getExemplarResponses().set(i, commandResult.getUpdatedContent());
+            isContentChanged = isContentChanged || commandResult.isContentChanged();
+        }
+
+        return isContentChanged;
     }
 
     @Override
     protected boolean updateSpanishContent(WerItem item, ContentUpdateCommand updateCommand) {
+        boolean isContentChanged;
         WerItemContent english = item.getCore().getEn();
         WerItemContent spanish = item.getTranslations().getEsp();
 
-        spanish.setPrompt(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt()));
-        spanish.setRubric(updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getRubric(), english.getRubric()));
+        ContentUpdateCommandResult commandResult =
+                updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getPrompt(), english.getPrompt());
+        spanish.setPrompt(commandResult.getUpdatedContent());
+        isContentChanged = commandResult.isContentChanged();
 
-        this.updateSpanishListOfStrings(
-            spanish.getExemplarResponses(), english.getExemplarResponses(), updateCommand);
+        commandResult = updateCommand.applyTranslatedContentUpdate(LANG_ESN, spanish.getRubric(), english.getRubric());
+        spanish.setRubric(commandResult.getUpdatedContent());
+        isContentChanged = isContentChanged || commandResult.isContentChanged();
 
-        return true;
+        boolean exemplarChanged =  this.updateSpanishListOfStrings(
+                spanish.getExemplarResponses(), english.getExemplarResponses(), updateCommand);
+
+        return isContentChanged || exemplarChanged;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/AbstractMigration.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/AbstractMigration.java
@@ -15,6 +15,7 @@ import org.opentestsystem.ap.common.security.model.ItemBankSystemUser;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdater;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterContext;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterFactory;
 import org.opentestsystem.ap.migration.gitlab.GitLabSyncManager;
 import org.opentestsystem.ap.migration.model.BranchEditedException;
@@ -298,6 +299,12 @@ public abstract class AbstractMigration implements Migration {
         ContentUpdater updater = this.contentUpdaterFactory.getContentUpdaterForType(itemEntity.getItemJson().getType());
         updater.updateContent(itemEntity.getItemJson(), contentUpdateCommand);
         return itemEntity;
+    }
+
+    protected ContentUpdaterContext migrateEntityContentWithCheck(ItemEntity itemEntity, ContentUpdateCommand contentUpdateCommand) {
+        ContentUpdater updater = this.contentUpdaterFactory.getContentUpdaterForType(itemEntity.getItemJson().getType());
+        updater.updateContent(itemEntity.getItemJson(), contentUpdateCommand);
+        return new ContentUpdaterContext(updater.contentChanged(), itemEntity);
     }
 
 }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration1615.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration1615.java
@@ -12,6 +12,7 @@ import org.opentestsystem.ap.common.saaif.mapper.model.SkipMigration;
 import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommandResult;
 import org.opentestsystem.ap.migration.model.MigrationContext;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
 import org.springframework.stereotype.Component;
@@ -39,7 +40,7 @@ public class Migration1615 extends AbstractMigration {
 
     public class Migration1615Command extends ContentUpdateCommand {
         @Override
-        public String applyEnglishContentUpdate(String englishContentHtml) {
+        public ContentUpdateCommandResult applyEnglishContentUpdate(String englishContentHtml) {
             final Document doc = newJsoupDocument(englishContentHtml);
 
             doc.getElementsByTag("img").forEach(image -> {
@@ -59,11 +60,11 @@ public class Migration1615 extends AbstractMigration {
                 }
             });
             // Important to remove new lines on mapped content
-            return MapperUtil.removeNewLine(doc.body().html());
+            return new ContentUpdateCommandResult(true, MapperUtil.removeNewLine(doc.body().html()));
         }
 
         @Override
-        public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
+        public ContentUpdateCommandResult applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
             return this.applyEnglishContentUpdate(translatedContent);
         }
     }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration2776.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration2776.java
@@ -10,6 +10,7 @@ import org.opentestsystem.ap.common.saaif.mapper.model.SkipMigration;
 import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommandResult;
 import org.opentestsystem.ap.migration.model.MigrationContext;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
 import org.springframework.stereotype.Component;
@@ -55,17 +56,17 @@ public class Migration2776 extends AbstractMigration {
 
     public class Migration2776Command extends ContentUpdateCommand {
         @Override
-        public String applyEnglishContentUpdate(String englishContentHtml) {
+        public ContentUpdateCommandResult applyEnglishContentUpdate(String englishContentHtml) {
             final Document doc = newJsoupDocument(englishContentHtml);
             removeStyleValuesFromElement(doc, "p");
             removeStyleValuesFromElement(doc, "span");
             removeStyleValuesFromElement(doc, "sup");
             // Important to remove new lines on mapped content
-            return MapperUtil.removeNewLine(doc.body().html());
+            return new ContentUpdateCommandResult(true, MapperUtil.removeNewLine(doc.body().html()));
         }
 
         @Override
-        public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
+        public ContentUpdateCommandResult applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
             return this.applyEnglishContentUpdate(translatedContent);
         }
 

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3246.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3246.java
@@ -15,6 +15,7 @@ import org.opentestsystem.ap.common.saaif.mapper.model.SkipMigration;
 import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommandResult;
 import org.opentestsystem.ap.migration.model.MigrationContext;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
 import org.springframework.stereotype.Component;
@@ -66,20 +67,20 @@ public class Migration3246 extends AbstractMigration {
     public static class Migration3246Command extends ContentUpdateCommand {
 
         @Override
-        public String applyEnglishContentUpdate(String richTextContent) {
+        public ContentUpdateCommandResult applyEnglishContentUpdate(String richTextContent) {
             if (this.shouldProcess(richTextContent)) {
                 Document doc = this.newJsoupDocument(richTextContent);
                 this.updateParagraphStyles(doc);
                 this.updateSpanStyles(doc);
                 // Important to remove new lines on mapped content
-                return MapperUtil.removeNewLine(doc.body().html());
+                return new ContentUpdateCommandResult(true, MapperUtil.removeNewLine(doc.body().html()));
             } else {
-                return richTextContent;
+                return new ContentUpdateCommandResult(false, richTextContent);
             }
         }
 
         @Override
-        public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
+        public ContentUpdateCommandResult applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
             return this.applyEnglishContentUpdate(translatedContent);
         }
 

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3270.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3270.java
@@ -10,9 +10,13 @@ import org.opentestsystem.ap.common.saaif.mapper.model.SkipMigration;
 import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
 import org.opentestsystem.ap.migration.ApplicationProperties;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommandResult;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterContext;
 import org.opentestsystem.ap.migration.model.MigrationContext;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.opentestsystem.ap.common.model.ModelConstants.ItemType.TYPE_TUT;
 
@@ -40,30 +44,35 @@ public class Migration3270 extends AbstractMigration {
             throw new SkipMigration("Item %s is not an imported Assessment item", itemEntity.getItemId());
         }
 
-        //TODO: Skip when item has no MathMl
-
         Migration3270Command migration3270Command = new Migration3270Command();
-        return migrateEntityContent(itemEntity, migration3270Command);
+        ContentUpdaterContext updaterContext = migrateEntityContentWithCheck(itemEntity, migration3270Command);
+        if (!updaterContext.isContentChanged()) {
+            throw new SkipMigration("Item %s does not contain MathMl that requires updating", itemEntity.getItemId());
+        }
+
+        return updaterContext.getMigratedEntity();
     }
 
     public static class Migration3270Command extends ContentUpdateCommand {
         @Override
-        public String applyEnglishContentUpdate(String englishContentHtml) {
+        public ContentUpdateCommandResult applyEnglishContentUpdate(String englishContentHtml) {
+            AtomicBoolean contentChanged = new AtomicBoolean(false);
             final Document doc = newJsoupDocument(englishContentHtml);
 
             doc.getElementsByTag(TAG_MATH).forEach(math -> {
                 math.getElementsByTag(TAG_MI).forEach(mi -> {
                     if (!mi.hasAttr(ATTR_MATHVARIANT) && mi.hasText()) {
                         mi.attr(ATTR_MATHVARIANT,ATTR_NORMAL);
+                        contentChanged.set(true);
                     }
                 });
             });
             // Important to remove new lines on mapped content
-            return MapperUtil.removeNewLine(doc.body().html());
+            return new ContentUpdateCommandResult(contentChanged.get(), MapperUtil.removeNewLine(doc.body().html()));
         }
 
         @Override
-        public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
+        public ContentUpdateCommandResult applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
             return this.applyEnglishContentUpdate(translatedContent);
         }
     }

--- a/src/main/java/org/opentestsystem/ap/migration/migration/Migration3270.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/Migration3270.java
@@ -1,0 +1,70 @@
+package org.opentestsystem.ap.migration.migration;
+
+import org.jsoup.nodes.Document;
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreItemManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.saaif.mapper.model.SkipMigration;
+import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.model.MigrationContext;
+import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
+import org.springframework.stereotype.Component;
+
+import static org.opentestsystem.ap.common.model.ModelConstants.ItemType.TYPE_TUT;
+
+@Component
+public class Migration3270 extends AbstractMigration {
+
+    public static String TAG_MATH = "math";
+    public static String TAG_MI = "mi";
+    public static String ATTR_MATHVARIANT = "mathvariant";
+    public static String ATTR_NORMAL = "normal";
+
+    public Migration3270(ApplicationDependencyProvider applicationDependencyProvider,
+                         ApplicationProperties applicationProperties,
+                         DataStoreDataManager dataManager,
+                         DataStoreItemManager dataStoreItemManager,
+                         DataStoreUtility dataStoreUtility,
+                         DataStoreAttachmentManager dataStoreAttachmentManager) {
+        super(applicationDependencyProvider, applicationProperties, dataManager,
+                dataStoreItemManager, dataStoreUtility, dataStoreAttachmentManager);
+    }
+
+    @Override
+    protected ItemEntity migrateEntity(final ItemEntity itemEntity, final MigrationContext migrationContext) {
+        if (TYPE_TUT.equals(itemEntity.getItemJson().getType()) || !itemEntity.getItemJson().isImported()) {
+            throw new SkipMigration("Item %s is not an imported Assessment item", itemEntity.getItemId());
+        }
+
+        //TODO: Skip when item has no MathMl
+
+        Migration3270Command migration3270Command = new Migration3270Command();
+        return migrateEntityContent(itemEntity, migration3270Command);
+    }
+
+    public static class Migration3270Command extends ContentUpdateCommand {
+        @Override
+        public String applyEnglishContentUpdate(String englishContentHtml) {
+            final Document doc = newJsoupDocument(englishContentHtml);
+
+            doc.getElementsByTag(TAG_MATH).forEach(math -> {
+                math.getElementsByTag(TAG_MI).forEach(mi -> {
+                    if (!mi.hasAttr(ATTR_MATHVARIANT) && mi.hasText()) {
+                        mi.attr(ATTR_MATHVARIANT,ATTR_NORMAL);
+                    }
+                });
+            });
+            // Important to remove new lines on mapped content
+            return MapperUtil.removeNewLine(doc.body().html());
+        }
+
+        @Override
+        public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
+            return this.applyEnglishContentUpdate(translatedContent);
+        }
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/migration/migration/migration2978/MathMLContentUpdateCommand.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/migration2978/MathMLContentUpdateCommand.java
@@ -6,6 +6,7 @@ import org.opentestsystem.ap.common.model.ItemImageResource;
 import org.opentestsystem.ap.common.saaif.mapper.model.IatImage;
 import org.opentestsystem.ap.common.saaif.mapper.util.MigrationMapperUtil;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommandResult;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -26,19 +27,21 @@ public class MathMLContentUpdateCommand extends ContentUpdateCommand {
     }
 
     @Override
-    public String applyEnglishContentUpdate(String englishContentHtml) {
-        return MigrationMapperUtil.applyMathMLToModelContent(englishContentHtml, itemSyncDir, images);
+    public ContentUpdateCommandResult applyEnglishContentUpdate(String englishContentHtml) {
+        return new ContentUpdateCommandResult(true,
+                MigrationMapperUtil.applyMathMLToModelContent(englishContentHtml, itemSyncDir, images));
     }
 
     @Override
-    public String applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
+    public ContentUpdateCommandResult applyTranslatedContentUpdate(String language, String translatedContent, String englishContent) {
         String mappedTranslatedContent = translatedContent;
         if (StringUtils.isNotBlank(translatedContent)) {
-            mappedTranslatedContent = this.applyEnglishContentUpdate(translatedContent);
+            ContentUpdateCommandResult commandResult = this.applyEnglishContentUpdate(translatedContent);
+            mappedTranslatedContent = commandResult.getUpdatedContent();
         }
         return this.isMathMLMatch(mappedTranslatedContent, englishContent)
-            ? StringUtils.EMPTY
-            : mappedTranslatedContent;
+            ? new ContentUpdateCommandResult(false, StringUtils.EMPTY)
+            : new ContentUpdateCommandResult(true, mappedTranslatedContent);
     }
 
     boolean isMathMLMatch(String translatedContent, String englishContent) {

--- a/src/main/java/org/opentestsystem/ap/migration/migration/migration3120/TtsViContentUpdateCommand.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/migration3120/TtsViContentUpdateCommand.java
@@ -33,6 +33,7 @@ import org.opentestsystem.ap.common.model.content.TiItemContent;
 import org.opentestsystem.ap.common.model.content.TutItemContent;
 import org.opentestsystem.ap.common.model.content.WerItemContent;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommandResult;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -70,13 +71,14 @@ public class TtsViContentUpdateCommand extends ContentUpdateCommand {
     }
 
     @Override
-    public String applyEnglishContentUpdate(final String englishContentHtml) {
-        return addTtsViWhereNeeded(super.newJsoupDocument(englishContentHtml)).html();
+    public ContentUpdateCommandResult applyEnglishContentUpdate(final String englishContentHtml) {
+        return new ContentUpdateCommandResult(true,
+                addTtsViWhereNeeded(super.newJsoupDocument(englishContentHtml)).html());
     }
 
     @Override
-    public String applyTranslatedContentUpdate(final String language, final String translatedContent, final String englishContent) {
-        return translatedContent;
+    public ContentUpdateCommandResult applyTranslatedContentUpdate(final String language, final String translatedContent, final String englishContent) {
+        return new ContentUpdateCommandResult(true, translatedContent);
     }
 
     private void updateImageFileNameToTtsViMap(Map<String, String> mappedIdToFilename, String html) {

--- a/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/TtsContentUpdateCommand.java
+++ b/src/main/java/org/opentestsystem/ap/migration/migration/migration3177/TtsContentUpdateCommand.java
@@ -8,6 +8,7 @@ import org.opentestsystem.ap.common.saaif.item.SaaifAccessElement;
 import org.opentestsystem.ap.common.saaif.item.SaaifContent;
 import org.opentestsystem.ap.common.saaif.transformer.MapperUtil;
 import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommand;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdateCommandResult;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,13 +33,13 @@ public class TtsContentUpdateCommand extends ContentUpdateCommand {
     }
 
     @Override
-    public String applyEnglishContentUpdate(final String englishContentHtml) {
-        return addTTSIfNeeded(englishContentHtml, LANG_ENU);
+    public ContentUpdateCommandResult applyEnglishContentUpdate(final String englishContentHtml) {
+        return new ContentUpdateCommandResult(true, addTTSIfNeeded(englishContentHtml, LANG_ENU));
     }
 
     @Override
-    public String applyTranslatedContentUpdate(final String language, final String translatedContent, final String englishContent) {
-        return addTTSIfNeeded(translatedContent, language);
+    public ContentUpdateCommandResult applyTranslatedContentUpdate(final String language, final String translatedContent, final String englishContent) {
+        return new ContentUpdateCommandResult(true, addTTSIfNeeded(translatedContent, language));
     }
 
     /**

--- a/src/test/java/org/opentestsystem/ap/migration/TestUtil.java
+++ b/src/test/java/org/opentestsystem/ap/migration/TestUtil.java
@@ -129,4 +129,48 @@ public class TestUtil {
 
         return accessElement;
     }
+
+    public static ImportItem getNewImportItemForCommandTesting(String enuPrompt) throws IOException {
+        ItemRelease itemRelease = new ItemRelease();
+        ItemRelease.Item item = new ItemRelease.Item();
+        ItemRelease.Item.Content content = new ItemRelease.Item.Content();
+        content.setStem(enuPrompt);
+        content.setLanguage(ModelConstants.ItemLanguage.LANG_ENU);
+        content.setApipAccessibility(new ItemRelease.Item.Content.ApipAccessibility());
+        content.getApipAccessibility().setAccessibilityInfo(new ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo());
+
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement textElement = TestUtil.getNewItemAccessElement();
+        textElement.setIdentifier("ae2");
+        textElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_TAG_3_BEGIN");
+        textElement.getContentLinkInfo().setType("Text");
+        textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciation("A B C D,");
+        textElement.getRelatedElementInfo().getReadAloud().setTextToSpeechPronunciationAlternate("ABCD");
+
+        ItemRelease.Item.Content.ApipAccessibility.AccessibilityInfo.AccessElement graphicElement = TestUtil.getNewItemAccessElement();
+        graphicElement.setIdentifier("ae4");
+        graphicElement.getContentLinkInfo().setItsLinkIdentifierRef("item_27005_stem");
+        graphicElement.getContentLinkInfo().setType("Graphic");
+        graphicElement.getContentLinkInfo().setSubtype("Generic");
+        graphicElement.getRelatedElementInfo().getReadAloud().setAudioText("Clockwise from the right, the figure reeds, e, c, b, a, D;");
+        graphicElement.getRelatedElementInfo().getBrailleText().setBrailleTextString("The figure contains a rectangle with the four corners labeled clockwise from the top left, A. , d, c, b. A diagonal line is drawn from point A. , to point c. Triangle A. , c, b, is shaded, triangle A. , c, d, is not. Triangle D, c, e, is a triangle connected to the rectangle. Triangle D, c, e, is shaded.");
+
+        content.getApipAccessibility().getAccessibilityInfo().getAccessElement().add(textElement);
+        content.getApipAccessibility().getAccessibilityInfo().getAccessElement().add(graphicElement);
+
+        item.getContent().add(content);
+        itemRelease.setItem(item);
+
+        ImportItem importItem = new ImportItem();
+        ItemProps itemProps = new ItemProps();
+        SmarterAppMetadata metadata = new SmarterAppMetadata();
+        metadata.setSubject("math");
+
+        importItem.setItemProps(itemProps);
+        importItem.setItemRelease(itemRelease);
+        importItem.setSmarterAppMetadata(metadata);
+        importItem.setExpandedImportItemPath(Files.createTempDirectory("tes"));
+        importItem.setItemImportSourcePath(Files.createTempDirectory("testSrc"));
+
+        return importItem;
+    }
 }

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3270Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3270Test.java
@@ -12,6 +12,19 @@ import org.opentestsystem.ap.common.datastore.DataStoreItemManager;
 import org.opentestsystem.ap.common.datastore.DataStoreUtility;
 import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
 import org.opentestsystem.ap.common.model.EbsrItem;
+import org.opentestsystem.ap.common.model.EqItem;
+import org.opentestsystem.ap.common.model.GiItem;
+import org.opentestsystem.ap.common.model.HtqoItem;
+import org.opentestsystem.ap.common.model.HtqsItem;
+import org.opentestsystem.ap.common.model.ItemOption;
+import org.opentestsystem.ap.common.model.McItem;
+import org.opentestsystem.ap.common.model.MiItem;
+import org.opentestsystem.ap.common.model.MsItem;
+import org.opentestsystem.ap.common.model.SaItem;
+import org.opentestsystem.ap.common.model.StimItem;
+import org.opentestsystem.ap.common.model.TiItem;
+import org.opentestsystem.ap.common.model.WerItem;
+import org.opentestsystem.ap.common.model.content.EbsrItemContent;
 import org.opentestsystem.ap.common.saaif.mapper.model.ImportItem;
 import org.opentestsystem.ap.common.saaif.mapper.util.MigrationFileUtil;
 import org.opentestsystem.ap.migration.ApplicationProperties;
@@ -22,6 +35,7 @@ import org.opentestsystem.ap.migration.model.MigrationContext;
 import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 import static org.mockito.Mockito.when;
@@ -54,6 +68,10 @@ public class Migration3270Test {
 
     private Migration3270 migration;
 
+    private static final String MATHML_CONTENT = "<p><span class=\"iat-glossary-term\" data-iat-glossary-term-id=\"1\">Enter</span> the unknown number to make the equation <span class=\"iat-glossary-term\" data-iat-glossary-term-id=\"2\">true</span>.<br /><br /><span class=\"iat-text2speech\" data-iat-tts=\"6 hundred 89 divided by 4 equals, open parenthesis, 4 hundred divided by 4, closed parenthesis, plus, open parenthesis, 2 hundred divided by 4, closed parenthesis, plus, open parenthesis, box divided by 4, closed parenthesis, plus, open parenthesis, 9 divided by 4, closed parenthesis.  From left to right and top to bottom, the equation tool reeds, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, point, box over box.\"><math xmlns:math=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mn>689</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn><mrow><mi /><mo stretchy=\"false\">=</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>400</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>200</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mi>□</mi><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>9</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow></mrow><annotation encoding=\"StarMath 5.0\">689`div`4`=`(400`div`4)`+`(200`div`4)`+`(□`div`4)`+`(9`div`4)</annotation></semantics></math> </span></p>";
+
+    private static final String UPDATED_MATHML = "<mi mathvariant=\"normal\">";
+
     @Before
     public void setUp() {
         when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
@@ -64,29 +82,355 @@ public class Migration3270Test {
                 dataStoreItemManager, dataStoreUtility, dataStoreAttachmentManager);
     }
 
-
     @Test
     public void shouldUpdateMathMlOnEbsrItem() throws IOException {
-        final String sampleStemContent = "<p><span class=\"iat-glossary-term\" data-iat-glossary-term-id=\"1\">Enter</span> the unknown number to make the equation <span class=\"iat-glossary-term\" data-iat-glossary-term-id=\"2\">true</span>.<br /><br /><span class=\"iat-text2speech\" data-iat-tts=\"6 hundred 89 divided by 4 equals, open parenthesis, 4 hundred divided by 4, closed parenthesis, plus, open parenthesis, 2 hundred divided by 4, closed parenthesis, plus, open parenthesis, box divided by 4, closed parenthesis, plus, open parenthesis, 9 divided by 4, closed parenthesis.  From left to right and top to bottom, the equation tool reeds, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, point, box over box.\"><math xmlns:math=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mn>689</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn><mrow><mi /><mo stretchy=\"false\">=</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>400</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>200</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mi>□</mi><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>9</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow></mrow><annotation encoding=\"StarMath 5.0\">689`div`4`=`(400`div`4)`+`(200`div`4)`+`(□`div`4)`+`(9`div`4)</annotation></semantics></math> </span></p>";
-
         ItemEntity entity = new ItemEntity("123", "master");
         EbsrItem item = new EbsrItem("123");
-        item.getCore().getEn().setPrompt(sampleStemContent);
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().setPartAPrompt(MATHML_CONTENT);
+        item.getCore().getEn().setPartBPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPartAPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPartBPrompt(MATHML_CONTENT);
         entity.setItemJson(item);
 
-        ImportItem importItem = TestUtil.getNewImportItemForCommandTesting(sampleStemContent);
-
-        when(migrationFileUtil.getImportItem(entity)).thenReturn(Optional.of(importItem));
-
-        MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
-
-        ItemEntity migratedEntity = migration.migrateEntity(entity, migrationContext);
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
 
         EbsrItem migratedItem = (EbsrItem) migratedEntity.getItemJson();
 
-        assert(migratedItem.getCore().getEn()
-                .getPrompt().contains("<mi mathvariant=\"normal\">"));
-
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getEn().getPartAPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getEn().getPartBPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getPartAPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getPartBPrompt().contains(UPDATED_MATHML));
     }
 
+    @Test
+    public void shouldUpdateMathMlOnEqItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        EqItem item = new EqItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getScoring().setRubric(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        EqItem migratedItem = (EqItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getScoring().getRubric().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnGiItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        GiItem item = new GiItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getScoring().setRubric(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        GiItem migratedItem = (GiItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getScoring().getRubric().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnHtqoItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        HtqoItem item = new HtqoItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().getHtqOrderable().setOrderableStrings(Arrays.asList(MATHML_CONTENT, MATHML_CONTENT, MATHML_CONTENT));
+        item.getCore().getScoring().setRubric(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().getHtqOrderable().setOrderableStrings(Arrays.asList(MATHML_CONTENT, MATHML_CONTENT, MATHML_CONTENT));
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        HtqoItem migratedItem = (HtqoItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getCore().getEn().getHtqOrderable().getOrderableStrings().forEach(value -> {
+            assert(value.contains(UPDATED_MATHML));
+        });
+        assert(migratedItem.getCore().getScoring().getRubric().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getTranslations().getEsp().getHtqOrderable().getOrderableStrings().forEach(value -> {
+            assert(value.contains(UPDATED_MATHML));
+        });
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnHtqsItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        HtqsItem item = new HtqsItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().getHtqSelectable().setInteractiveText(MATHML_CONTENT);
+        item.getCore().getScoring().setRubric(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().getHtqSelectable().setInteractiveText(MATHML_CONTENT);
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        HtqsItem migratedItem = (HtqsItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getEn().getHtqSelectable().getInteractiveText().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getScoring().getRubric().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getHtqSelectable().getInteractiveText().contains(UPDATED_MATHML));
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnMcItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        McItem item = new McItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "1", true, ""));
+        item.getCore().getEn().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "2", true, ""));
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "1", true, ""));
+        item.getTranslations().getEsp().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "2", true, ""));
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        McItem migratedItem = (McItem) migratedEntity.getItemJson();
+
+        assert (migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getCore().getEn().getOptions().forEach(option -> {
+            assert(option.getText().contains(UPDATED_MATHML));
+        });
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getTranslations().getEsp().getOptions().forEach(option -> {
+            assert(option.getText().contains(UPDATED_MATHML));
+        });
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnMiItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        MiItem item = new MiItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().getTable().getColumns().forEach(column ->
+                column.setLabel(MATHML_CONTENT));
+        item.getCore().getEn().getTable().getRows().forEach(row -> {
+            row.getCells().forEach(cell -> {
+                if (cell.isLabel()) {
+                    cell.setValue(MATHML_CONTENT);
+                }
+            });
+        });
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().getTable().getColumns().forEach(column ->
+                column.setLabel(MATHML_CONTENT));
+        item.getTranslations().getEsp().getTable().getRows().forEach(row -> {
+            row.getCells().forEach(cell -> {
+                if (cell.isLabel()) {
+                    cell.setValue(MATHML_CONTENT);
+                }
+            });
+        });
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        MiItem migratedItem = (MiItem) migratedEntity.getItemJson();
+
+        assert (migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        item.getCore().getEn().getTable().getColumns().forEach(column -> {
+           assert(column.getLabel().contains(UPDATED_MATHML));
+        });
+        item.getCore().getEn().getTable().getRows().forEach(row -> {
+           row.getCells().forEach(cell ->  {
+               assert !cell.isLabel() || (((String) cell.getValue()).contains(UPDATED_MATHML));
+           });
+        });
+
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        item.getTranslations().getEsp().getTable().getColumns().forEach(column -> {
+            assert(column.getLabel().contains(UPDATED_MATHML));
+        });
+        item.getTranslations().getEsp().getTable().getRows().forEach(row -> {
+            row.getCells().forEach(cell ->  {
+                assert !cell.isLabel() || (((String) cell.getValue()).contains(UPDATED_MATHML));
+            });
+        });
+    }
+
+    @Test
+    public void shouldUpdateMathMsOnMcItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        MsItem item = new MsItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "1", true, ""));
+        item.getCore().getEn().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "2", true, ""));
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "1", true, ""));
+        item.getTranslations().getEsp().getOptions().add(ItemOption.newItemOption(MATHML_CONTENT, "2", true, ""));
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        MsItem migratedItem = (MsItem) migratedEntity.getItemJson();
+
+        assert (migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getCore().getEn().getOptions().forEach(option -> {
+            assert(option.getText().contains(UPDATED_MATHML));
+        });
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getTranslations().getEsp().getOptions().forEach(option -> {
+            assert(option.getText().contains(UPDATED_MATHML));
+        });
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnSaItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        SaItem item = new SaItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().setExemplarResponses(Arrays.asList(MATHML_CONTENT, MATHML_CONTENT, MATHML_CONTENT));
+        item.getCore().getEn().setRubrics(Arrays.asList(MATHML_CONTENT, MATHML_CONTENT, MATHML_CONTENT));
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().setExemplarResponses(Arrays.asList(MATHML_CONTENT, MATHML_CONTENT, MATHML_CONTENT));
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        SaItem migratedItem = (SaItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getCore().getEn().getExemplarResponses().forEach(value -> {
+            assert(value.contains(UPDATED_MATHML));
+        });
+        migratedItem.getCore().getEn().getRubrics().forEach(value -> {
+            assert(value.contains(UPDATED_MATHML));
+        });
+
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getTranslations().getEsp().getExemplarResponses().forEach(value -> {
+            assert(value.contains(UPDATED_MATHML));
+        });
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnStimItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        StimItem item = new StimItem("123");
+        item.getCore().getEn().setContent(MATHML_CONTENT);
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        StimItem migratedItem = (StimItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getContent().contains(UPDATED_MATHML));
+    }
+
+
+    @Test
+    public void shouldUpdateMathMlOnTiItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        TiItem item = new TiItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getScoring().setRubric(MATHML_CONTENT);
+        item.getCore().getEn().getTable().setTitle(MATHML_CONTENT);
+        item.getCore().getEn().getTable().getColumns().forEach(column ->
+                column.setLabel(MATHML_CONTENT));
+        item.getCore().getEn().getTable().getRows().forEach(row -> {
+            row.getCells().forEach(cell -> {
+                if (cell.isLabel()) {
+                    cell.setValue(MATHML_CONTENT);
+                }
+            });
+        });
+
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().getTable().setTitle(MATHML_CONTENT);
+        item.getTranslations().getEsp().getTable().getColumns().forEach(column ->
+                column.setLabel(MATHML_CONTENT));
+        item.getTranslations().getEsp().getTable().getRows().forEach(row -> {
+            row.getCells().forEach(cell -> {
+                if (cell.isLabel()) {
+                    cell.setValue(MATHML_CONTENT);
+                }
+            });
+        });
+
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        TiItem migratedItem = (TiItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getScoring().getRubric().contains(UPDATED_MATHML));
+        assert(migratedItem.getCore().getEn().getTable().getTitle().contains(UPDATED_MATHML));
+        item.getCore().getEn().getTable().getColumns().forEach(column -> {
+            assert(column.getLabel().contains(UPDATED_MATHML));
+        });
+        item.getCore().getEn().getTable().getRows().forEach(row -> {
+            row.getCells().forEach(cell ->  {
+                assert !cell.isLabel() || (((String) cell.getValue()).contains(UPDATED_MATHML));
+            });
+        });
+
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        assert(migratedItem.getTranslations().getEsp().getTable().getTitle().contains(UPDATED_MATHML));
+        item.getTranslations().getEsp().getTable().getColumns().forEach(column -> {
+            assert(column.getLabel().contains(UPDATED_MATHML));
+        });
+        item.getTranslations().getEsp().getTable().getRows().forEach(row -> {
+            row.getCells().forEach(cell ->  {
+                assert !cell.isLabel() || (((String) cell.getValue()).contains(UPDATED_MATHML));
+            });
+        });
+    }
+
+    @Test
+    public void shouldUpdateMathMlOnWerItem() throws IOException {
+        ItemEntity entity = new ItemEntity("123", "master");
+        WerItem item = new WerItem("123");
+        item.getCore().getEn().setPrompt(MATHML_CONTENT);
+        item.getCore().getEn().setExemplarResponses(Arrays.asList(MATHML_CONTENT, MATHML_CONTENT, MATHML_CONTENT));
+        item.getCore().getEn().setRubric(MATHML_CONTENT);
+        item.getTranslations().getEsp().setPrompt(MATHML_CONTENT);
+        item.getTranslations().getEsp().setExemplarResponses(Arrays.asList(MATHML_CONTENT, MATHML_CONTENT, MATHML_CONTENT));
+        entity.setItemJson(item);
+
+        ItemEntity migratedEntity = getMigratedItemEntity(entity);
+
+        WerItem migratedItem = (WerItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getCore().getEn().getExemplarResponses().forEach(value -> {
+            assert(value.contains(UPDATED_MATHML));
+        });
+        migratedItem.getCore().getEn().getRubric().contains(UPDATED_MATHML);
+
+        assert(migratedItem.getTranslations().getEsp().getPrompt().contains(UPDATED_MATHML));
+        migratedItem.getTranslations().getEsp().getExemplarResponses().forEach(value -> {
+            assert(value.contains(UPDATED_MATHML));
+        });
+    }
+
+
+    private ItemEntity getMigratedItemEntity(ItemEntity itemEntity) throws IOException {
+        ImportItem importItem = TestUtil.getNewImportItemForCommandTesting(MATHML_CONTENT);
+
+        when(migrationFileUtil.getImportItem(itemEntity)).thenReturn(Optional.of(importItem));
+
+        MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
+
+        return migration.migrateEntity(itemEntity, migrationContext);
+    }
 }

--- a/src/test/java/org/opentestsystem/ap/migration/migration/Migration3270Test.java
+++ b/src/test/java/org/opentestsystem/ap/migration/migration/Migration3270Test.java
@@ -1,0 +1,92 @@
+package org.opentestsystem.ap.migration.migration;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.common.datastore.DataStoreAttachmentManager;
+import org.opentestsystem.ap.common.datastore.DataStoreDataManager;
+import org.opentestsystem.ap.common.datastore.DataStoreItemManager;
+import org.opentestsystem.ap.common.datastore.DataStoreUtility;
+import org.opentestsystem.ap.common.datastore.entity.ItemEntity;
+import org.opentestsystem.ap.common.model.EbsrItem;
+import org.opentestsystem.ap.common.saaif.mapper.model.ImportItem;
+import org.opentestsystem.ap.common.saaif.mapper.util.MigrationFileUtil;
+import org.opentestsystem.ap.migration.ApplicationProperties;
+import org.opentestsystem.ap.migration.TestUtil;
+import org.opentestsystem.ap.migration.contentupdater.ContentUpdaterFactory;
+import org.opentestsystem.ap.migration.gitlab.GitLabSyncManager;
+import org.opentestsystem.ap.migration.model.MigrationContext;
+import org.opentestsystem.ap.migration.util.ApplicationDependencyProvider;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Migration3270Test {
+    @Mock
+    private ApplicationProperties applicationProperties;
+
+    @Mock
+    private DataStoreDataManager dataManager;
+
+    @Mock
+    private DataStoreItemManager dataStoreItemManager;
+
+    @Mock
+    private DataStoreUtility dataStoreUtility;
+
+    @Mock
+    private DataStoreAttachmentManager dataStoreAttachmentManager;
+
+    @Mock
+    private MigrationFileUtil migrationFileUtil;
+
+    @Mock
+    private GitLabSyncManager gitLabSyncManager;
+
+    @Mock
+    private ApplicationDependencyProvider applicationDependencyProvider;
+
+    private Migration3270 migration;
+
+    @Before
+    public void setUp() {
+        when(applicationDependencyProvider.getMigrationFileUtil()).thenReturn(migrationFileUtil);
+        when(applicationDependencyProvider.getItemBankSyncManager()).thenReturn(gitLabSyncManager);
+        when(applicationDependencyProvider.getContentUpdaterFactory()).thenReturn(new ContentUpdaterFactory());
+
+        migration = new Migration3270(applicationDependencyProvider, applicationProperties, dataManager,
+                dataStoreItemManager, dataStoreUtility, dataStoreAttachmentManager);
+    }
+
+
+    @Test
+    public void shouldUpdateMathMlOnEbsrItem() throws IOException {
+        final String sampleStemContent = "<p><span class=\"iat-glossary-term\" data-iat-glossary-term-id=\"1\">Enter</span> the unknown number to make the equation <span class=\"iat-glossary-term\" data-iat-glossary-term-id=\"2\">true</span>.<br /><br /><span class=\"iat-text2speech\" data-iat-tts=\"6 hundred 89 divided by 4 equals, open parenthesis, 4 hundred divided by 4, closed parenthesis, plus, open parenthesis, 2 hundred divided by 4, closed parenthesis, plus, open parenthesis, box divided by 4, closed parenthesis, plus, open parenthesis, 9 divided by 4, closed parenthesis.  From left to right and top to bottom, the equation tool reeds, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, point, box over box.\"><math xmlns:math=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mn>689</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn><mrow><mi /><mo stretchy=\"false\">=</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>400</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>200</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mi>□</mi><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow><mrow><mi /><mo stretchy=\"false\">+</mo><mi /></mrow><mrow><mo stretchy=\"false\">(</mo><mrow><mn>9</mn><mrow><mi /><mo stretchy=\"false\">÷</mo><mi /></mrow><mn>4</mn></mrow><mo stretchy=\"false\">)</mo></mrow></mrow><annotation encoding=\"StarMath 5.0\">689`div`4`=`(400`div`4)`+`(200`div`4)`+`(□`div`4)`+`(9`div`4)</annotation></semantics></math> </span></p>";
+
+        ItemEntity entity = new ItemEntity("123", "master");
+        EbsrItem item = new EbsrItem("123");
+        item.getCore().getEn().setPrompt(sampleStemContent);
+        entity.setItemJson(item);
+
+        ImportItem importItem = TestUtil.getNewImportItemForCommandTesting(sampleStemContent);
+
+        when(migrationFileUtil.getImportItem(entity)).thenReturn(Optional.of(importItem));
+
+        MigrationContext migrationContext = new MigrationContext("1", new ApplicationProperties.MigrationDefinition(), importItem);
+
+        ItemEntity migratedEntity = migration.migrateEntity(entity, migrationContext);
+
+        EbsrItem migratedItem = (EbsrItem) migratedEntity.getItemJson();
+
+        assert(migratedItem.getCore().getEn()
+                .getPrompt().contains("<mi mathvariant=\"normal\">"));
+
+    }
+
+}


### PR DESCRIPTION
Created migration that adds `mathvariant="normal"` to all `<mi>` MathMl elements.

Refactored the `ContentUpdateCommand` to return a model that indicates if the Html content was changed.

This PR currently includes all code changes. No tests have been updated.

Since the changes are extensive it is recommended to pull this branch locally to review. Please begin with `Migration3270.java` which is the only migration that currently skips when no content was updated.


